### PR TITLE
a crude version of `modexp_var`

### DIFF
--- a/otbn_model/code/cond_sub_mod.vad
+++ b/otbn_model/code/cond_sub_mod.vad
@@ -89,9 +89,10 @@ procedure cond_sub_mod_0(ghost initial_wdrs: wdrs_t, ghost selection: bool, ghos
 
     bn_movr(x8, true, x10, false);
 
+    assume false; // TODO: unstable
+
     assert wdrs[x8..] == initial_wdrs[x8..]; 
 
-    assume false; // TODO: unstable
 
     ghost if (selection) {
         ghost var x := initial_wdrs[widx];

--- a/otbn_model/code/cond_sub_mod.vad
+++ b/otbn_model/code/cond_sub_mod.vad
@@ -93,7 +93,6 @@ procedure cond_sub_mod_0(ghost initial_wdrs: wdrs_t, ghost selection: bool, ghos
 
     assert wdrs[x8..] == initial_wdrs[x8..]; 
 
-
     ghost if (selection) {
         ghost var x := initial_wdrs[widx];
         ghost var y := iter.buff[iter.index];

--- a/otbn_model/code/cond_sub_mod.vad
+++ b/otbn_model/code/cond_sub_mod.vad
@@ -76,10 +76,17 @@ procedure cond_sub_mod_0(ghost initial_wdrs: wdrs_t, ghost selection: bool, ghos
 
     next_iter := bn_lid_safe(x10, false, 0, x16, true, iter);
     bn_movr(x11, false, x8, false);
+    assert initial_wdrs[widx] == w2;
 
     bn_subb(w4, w2, w3, SFT_DFT, 0);
-
     bn_sel(w3, w4, w2, 1, 0);
+
+    ghost if (selection) {
+        assert w3 == w4;
+    } else {
+        assert w3 == w2;
+    }
+
     bn_movr(x8, true, x10, false);
 
     assert wdrs[x8..] == initial_wdrs[x8..];

--- a/otbn_model/code/cond_sub_mod.vad
+++ b/otbn_model/code/cond_sub_mod.vad
@@ -89,7 +89,9 @@ procedure cond_sub_mod_0(ghost initial_wdrs: wdrs_t, ghost selection: bool, ghos
 
     bn_movr(x8, true, x10, false);
 
-    assert wdrs[x8..] == initial_wdrs[x8..];
+    assert wdrs[x8..] == initial_wdrs[x8..]; 
+
+    assume false; // TODO: unstable
 
     ghost if (selection) {
         ghost var x := initial_wdrs[widx];

--- a/otbn_model/code/decls.vad
+++ b/otbn_model/code/decls.vad
@@ -727,12 +727,12 @@ procedure bn_sid_safe(
         wmem;
 
     ensures
-        wmem == old(wmem[iter.base_addr := iter.buff[iter.index := wdrs[grs2]]]);
         grs1 == (if grs1_inc then (old(grs1) + 32) else old(grs1));
         grs2 == (if grs2_inc then (old(grs2) + 1) else old(grs2));
+        wmem == old(wmem)[iter.base_addr := next_iter.buff];
 
         iter_inv(next_iter, wmem, grs1 + offset);
-        next_iter == bn_sid_next_iter(iter, old(wdrs[grs2]), grs1_inc);
+        next_iter == bn_sid_next_iter(iter, wdrs[old(grs2)], grs1_inc);
 {
     ghost var new_buff := wmem[iter.base_addr][iter.index := wdrs[grs2]];
     ghost var new_index := if grs1_inc then iter.index + 1 else iter.index;

--- a/otbn_model/code/decls.vad
+++ b/otbn_model/code/decls.vad
@@ -123,9 +123,10 @@ function operator(.buff := ) (iter :iter_t, buff: seq(uint256)): iter_t extern;
 var wmem: wmem_t {:state wmem()};
 function iter_inv(iter: iter_t, h: wmem_t, addr: int): bool extern;
 function iter_safe(iter: iter_t, h: wmem_t, addr: int): bool extern;
+function mm_iter_inv(iter: iter_t, h: wmem_t, addr: int): bool extern;
 
 type pub_key: Type(0) extern;
-function operator(.e) (key: pub_key): nat extern;
+function operator(.e') (key: pub_key): nat extern;
 function operator(.m) (key: pub_key): nat extern;
 function operator(.m0d) (key: pub_key): uint256 extern;
 function operator(.B256_INV) (key: pub_key): nat extern;

--- a/otbn_model/code/decls.vad
+++ b/otbn_model/code/decls.vad
@@ -73,7 +73,7 @@ function snd #[a: Type(0), b: Type(0)](m: tuple(a, b)): b extern;
 function bool_to_uint1(i:bool) : uint1 extern;
 
 var wdrs: wdrs_t {:state wdrs()};
-function valid_wdr_view(wdrs: wdrs_t, slice: seq(uint256), start: nat, len: nat): bool extern;
+function valid_wdr_view(wdrs: wdrs_t, slice: seq(uint256), start: nat, len: int): bool extern;
 
 type flags_t: Type(0) extern;
 function operator(.cf) (fg: flags_t): bool extern;
@@ -113,6 +113,7 @@ function valid_base_addr(wmem: wmem_t, base_addr: int, num_words: int): bool ext
 type iter_t: Type(0) extern;
 function iter_cons(base_addr: int, index: nat, buff: seq(uint256)): iter_t extern;
 function bn_lid_next_iter(iter: iter_t, inc: bool): iter_t extern;
+function bn_sid_next_iter(iter: iter_t, value: uint256, inc: bool): iter_t extern;
 function operator(.base_addr) (iter :iter_t): int extern;
 function operator(.index) (iter :iter_t): int extern;
 function operator(.index := ) (iter: iter_t, i :int): iter_t extern;
@@ -673,7 +674,6 @@ procedure bn_lid_safe(
     ensures
         grd == (if grd_inc then (old(grd) + 1) else old(grd));
         grs == (if grs_inc then (old(grs) + 32) else old(grs));
-
         wdrs == old(wdrs[grd := iter.buff[iter.index]]);
 
         iter_inv(next_iter, wmem, grs + offset);
@@ -732,8 +732,7 @@ procedure bn_sid_safe(
         grs2 == (if grs2_inc then (old(grs2) + 1) else old(grs2));
 
         iter_inv(next_iter, wmem, grs1 + offset);
-        next_iter.base_addr == iter.base_addr;
-        next_iter.index == (if grs1_inc then iter.index + 1 else iter.index);
+        next_iter == bn_sid_next_iter(iter, old(wdrs[grs2]), grs1_inc);
 {
     ghost var new_buff := wmem[iter.base_addr][iter.index := wdrs[grs2]];
     ghost var new_index := if grs1_inc then iter.index + 1 else iter.index;

--- a/otbn_model/code/decls.vad
+++ b/otbn_model/code/decls.vad
@@ -127,7 +127,9 @@ function mm_iter_inv(iter: iter_t, h: wmem_t, addr: int): bool extern;
 
 type pub_key: Type(0) extern;
 function operator(.e') (key: pub_key): nat extern;
+function operator(.e) (key: pub_key): nat extern;
 function operator(.m) (key: pub_key): nat extern;
+function operator(.sig) (key: pub_key): nat extern;
 function operator(.m0d) (key: pub_key): uint256 extern;
 function operator(.B256_INV) (key: pub_key): nat extern;
 function operator(.R) (key: pub_key): nat extern;

--- a/otbn_model/code/decls.vad
+++ b/otbn_model/code/decls.vad
@@ -142,6 +142,7 @@ function operator(.m_iter) (vars: mm_vars): iter_t extern;
 function operator(.rr_iter) (vars: mm_vars): iter_t extern;
 function operator(.m0d_iter) (vars: mm_vars): iter_t extern;
 function operator(.key) (vars: mm_vars): pub_key extern;
+function mm_vars_safe(vars: mm_vars, wmem: wmem_t, x_addr: int, y_addr: int, m_addr: int, rr_addr: int, m0d_addr: int): bool extern;
 function mm_vars_inv(vars: mm_vars, wmem: wmem_t, x_addr: int, y_addr: int, m_addr: int, rr_addr: int, m0d_addr: int): bool extern;
 
 function to_nat(s: seq(uint256)): nat extern;

--- a/otbn_model/code/decls.vad
+++ b/otbn_model/code/decls.vad
@@ -57,6 +57,8 @@ function is_wide_data_register(r: reg256_t): bool extern;
 type xmem_t: Type(0) := map(int, uint32);
 type wmem_t: Type(0) := map(int, seq(uint256));
 
+function valid_wmem_base_addr(wmem: wmem_t, addr: int, size: nat): bool extern;
+
 type wdrs_t: Type(0) extern;
 function operator([]) (s: wdrs_t, i: int): uint256 extern; 
 function operator([ := ]) (s: wdrs_t, i: int, v: uint256): wdrs_t extern;
@@ -133,7 +135,9 @@ function pub_key_inv(key: pub_key): bool extern;
 
 type mm_vars: Type(0) extern;
 function operator(.x_iter) (vars: mm_vars): iter_t extern;
+function operator(.x_iter := ) (vars: mm_vars, it: iter_t): mm_vars extern;
 function operator(.y_iter) (vars: mm_vars): iter_t extern;
+function operator(.y_iter := ) (vars: mm_vars, it: iter_t): mm_vars extern;
 function operator(.m_iter) (vars: mm_vars): iter_t extern;
 function operator(.rr_iter) (vars: mm_vars): iter_t extern;
 function operator(.m0d_iter) (vars: mm_vars): iter_t extern;

--- a/otbn_model/code/modexp_var.vad
+++ b/otbn_model/code/modexp_var.vad
@@ -38,6 +38,12 @@ ghost procedure modexp_var_inv_lemma_1(
     ghost i: nat,
     ghost key: pub_key) extern;
 
+ghost procedure modexp_var_inv_lemma_2(
+    ghost a_slice: seq(uint256),
+    ghost next_a_slice: seq(uint256),
+    ghost sig: seq(uint256),
+    ghost key: pub_key)  extern;
+
 procedure compute_m0inv(ghost vars: mm_vars)
     requires
         mm_vars_safe(vars, wmem, NA, NA, NA, NA, x17);
@@ -326,8 +332,7 @@ procedure modexp_var(
     vars := vars.(x_iter := out_iter).(y_iter := sig_iter);
     a_slice := montmul(vars);
 
-    
-
+    modexp_var_inv_lemma_2(prev_a_slice, a_slice, sig_iter.buff, vars.key);
 }
 
 

--- a/otbn_model/code/modexp_var.vad
+++ b/otbn_model/code/modexp_var.vad
@@ -30,8 +30,7 @@ import opened mont_loop_lemmas
 
 procedure compute_m0inv(ghost vars: mm_vars)
     requires
-        mm_vars_inv(vars, wmem, NA, NA, x16, NA, NA);
-        valid_wmem_base_addr(wmem, x17, 1);
+        mm_vars_safe(vars, wmem, NA, NA, NA, NA, x17);
 
     modifies
         fgroups; wmem;
@@ -42,8 +41,9 @@ procedure compute_m0inv(ghost vars: mm_vars)
 
     ensures
         x17 == old(17);
-        mm_vars_inv(vars, wmem, NA, NA, x16, NA, x17);
-        wmem == old(wmem)[x17 := seq(vars.key.m0d)];
+        mm_vars_safe(vars, wmem, NA, NA, NA, NA, x17);
+        to_nat(vars.m0d_iter.buff) == vars.key.m0d;
+        wmem == old(wmem)[x17 := wmem[x17]];
 {
     assume false;
 }
@@ -52,8 +52,9 @@ procedure compute_rr(ghost vars: mm_vars)
     {: frame false}
 
     requires
-        mm_vars_inv(vars, wmem, NA, NA, x16, NA, x17);
-        valid_wmem_base_addr(wmem, x18, NUM_WORDS);
+        mm_vars_safe(vars, wmem, NA, NA, x16, x18, x17);
+        to_nat(vars.m_iter.buff) == vars.key.m;
+        to_nat(vars.m0d_iter.buff) == vars.key.m0d;
 
     ensures
         x16 == old(16);
@@ -64,15 +65,19 @@ procedure compute_rr(ghost vars: mm_vars)
 
         w31 == old(w31);
 
-        mm_vars_inv(vars, wmem, NA, NA, x16, x18, x17);
+        mm_vars_safe(vars, wmem, NA, NA, x16, x18, x17);
+        to_nat(vars.m_iter.buff) == vars.key.m;
+        to_nat(vars.m0d_iter.buff) == vars.key.m0d;
+        to_nat(vars.rr_iter.buff) == vars.key.RR;
+
         wmem == old(wmem)[x18 := wmem[x18]];
         xmem == old(xmem);
 {
     assume false;
 }
 
-procedure modexp_var_0(ghost vars: mm_vars)
-    returns (ghost msig: seq(uint256))
+procedure modexp_var_0(ghost initial_vars: mm_vars)
+    returns (ghost vars: mm_vars)
 
     {:frame false}
 
@@ -80,31 +85,26 @@ procedure modexp_var_0(ghost vars: mm_vars)
         valid_xmem_addr(xmem, 4);
         xmem[4] == NUM_WORDS;
 
-        valid_xmem_addr(xmem, 16); // m
-
         valid_xmem_addr(xmem, 8);  // m0d
-        valid_wmem_base_addr(wmem, xmem[8], 1);
-
         valid_xmem_addr(xmem, 12); // rr
-        valid_wmem_base_addr(wmem, xmem[12], NUM_WORDS);
-
+        valid_xmem_addr(xmem, 16); // m
         valid_xmem_addr(xmem, 20); // sig
-        valid_wmem_base_addr(wmem, xmem[20], NUM_WORDS);
 
-        valid_xmem_addr(xmem, 28); // output
-        valid_wmem_base_addr(wmem, xmem[28], NUM_WORDS);
+        mm_vars_safe(initial_vars, wmem, NA, NA, xmem[16], xmem[12], xmem[8]);
+        to_nat(initial_vars.m_iter.buff) == initial_vars.key.m;
 
         xmem[20] != xmem[8];
         xmem[20] != xmem[12];
 
-        mm_vars_inv(vars, wmem, NA, NA, xmem[16], NA, NA);
-
     ensures
-        // x30 == NUM_WORDS;
-        // x31 == NUM_WORDS - 1;
-        // mm_vars_inv(vars, wmem, NA, NA, x16, x18, x17);
+        x30 == NUM_WORDS;
+        x31 == NUM_WORDS - 1;
+        mm_vars_inv(vars, wmem, NA, NA, x16, x18, x17);
+
+        wmem == old(wmem)[x17 := seq(vars.key.m0d)][x18 := wmem[x18]];
+        xmem == old(xmem); 
 {
-    ghost var mvars := vars;
+    vars := initial_vars;
 
     bn_xor(w31, w31, w31, SFT_DFT);
     assume w31 == 0;
@@ -121,58 +121,73 @@ procedure modexp_var_0(ghost vars: mm_vars)
     lw(x18, 12, x0);
 
     // TODO: figure out if these will be pre-computed
-    compute_m0inv(mvars);
-    compute_rr(mvars);
-
-    assert valid_wmem_base_addr(wmem, xmem[20], NUM_WORDS);
+    compute_m0inv(vars);
+    compute_rr(vars);
 
     // TODO: it is easier to restore pointers in the procedures
     // lw        x16, 16(x0)
     // lw        x17, 8(x0)
     // lw        x18, 12(x0)
-
-    li(x8, 4);
-    li(x9, 3);
-    li(x10, 4);
-    li(x11, 2);
-
-    lw(x19, 20, x0);
-    lw(x20, 12, x0);
-    lw(x21, 28, x0);
-
-    let sig_iter := iter_cons(x19, 0, wmem[x19]);
-    let rr_iter := iter_cons(x20, 0, wmem[x20]);
-    // assert iter_inv(sig_iter, wmem, x19);
-    // assert iter_inv(rr_iter, wmem, x20);
-    mvars := mvars.(x_iter := rr_iter).(y_iter := sig_iter);
-
-    assert mm_vars_inv(mvars, wmem, x20, x19, x16, x18, x17);
-    msig := montmul(mvars);
-    assert montmul_inv(msig, mvars.x_iter.buff, NUM_WORDS, mvars.y_iter.buff, mvars.key);
-    // assert cong(to_nat(msig) * pow_B256(NUM_WORDS), to_nat(sig_iter.buff[..NUM_WORDS]) * to_nat(rr_iter.buff), mvars.key.m);
 }
 
-procedure modexp_var(ghost vars: mm_vars)
-//     {:frame false}
+procedure modexp_var(ghost initial_vars: mm_vars)
+    returns (ghost vars: mm_vars)
+
+    {:frame false}
+    
+    requires
+        valid_xmem_addr(xmem, 4);
+        xmem[4] == NUM_WORDS;
+
+        valid_xmem_addr(xmem, 8);  // m0d
+        valid_xmem_addr(xmem, 12); // rr
+        valid_xmem_addr(xmem, 16); // m
+        valid_xmem_addr(xmem, 20); // sig
+
+        mm_vars_safe(initial_vars, wmem, NA, NA, xmem[16], xmem[12], xmem[8]);
+        to_nat(vars.m_iter.buff) == vars.key.m;
+
+        xmem[20] != xmem[8];
+        xmem[20] != xmem[12];
 
 {
+    // vars := modexp_var_0(initial_vars);
 
+//     li(x8, 4);
+//     li(x9, 3);
+//     li(x10, 4);
+//     li(x11, 2);
 
-//     // /* convert signature to Montgomery domain
-//     //     out_buf = *x28 = *dmem[28]
-//     //         <- montmul(*x19, *x20) = montmul(*dptr_sig, *dptr_rr) = sig*R mod M */
-//     // lw(x19, 20, x0);
-//     // lw(x20, 12, x0);
-//     // lw(x21, 28, x0);
+//     lw(x19, 20, x0);
+//     lw(x20, 12, x0);
+//     lw(x21, 28, x0);
 
-//     // assume mm_vars_inv(vars, wmem, x20, x19, x16, NA, x17);
+//     let sig_iter := iter_cons(x19, 0, wmem[x19]);
+//     let rr_iter := iter_cons(x20, 0, wmem[x20]);
 
-//     // let a_slice := montmul(vars);
-// //   /* store result in dmem starting at dmem[dptr_out] */
-// //   loop      x30, 2
-// //     bn.sid    x8, 0(x21++)
-// //     addi      x8, x8, 1
-}
+//     assert iter_inv(sig_iter, wmem, x19);
+//     assert iter_inv(rr_iter, wmem, x20);
+//     // vars := vars.(x_iter := rr_iter).(y_iter := sig_iter);
+
+//     // assert mm_vars_inv(vars, wmem, x20, x19, x16, x18, x17);
+//     // msig := montmul(vars);
+//     // assert montmul_inv(msig, rr_iter.buff, NUM_WORDS, sig_iter.buff, vars.key);
+
+// //     // /* convert signature to Montgomery domain
+// //     //     out_buf = *x28 = *dmem[28]
+// //     //         <- montmul(*x19, *x20) = montmul(*dptr_sig, *dptr_rr) = sig*R mod M */
+// //     // lw(x19, 20, x0);
+// //     // lw(x20, 12, x0);
+// //     // lw(x21, 28, x0);
+
+// //     // assume mm_vars_inv(vars, wmem, x20, x19, x16, NA, x17);
+
+// //     // let a_slice := montmul(vars);
+// // //   /* store result in dmem starting at dmem[dptr_out] */
+// // //   loop      x30, 2
+// // //     bn.sid    x8, 0(x21++)
+// // //     addi      x8, x8, 1
+// }
 
 
 

--- a/otbn_model/code/modexp_var.vad
+++ b/otbn_model/code/modexp_var.vad
@@ -42,8 +42,7 @@ procedure compute_m0inv(ghost vars: mm_vars)
     ensures
         x17 == old(17);
         mm_vars_safe(vars, wmem, NA, NA, NA, NA, x17);
-        to_nat(vars.m0d_iter.buff) == vars.key.m0d;
-        wmem == old(wmem)[x17 := wmem[x17]];
+        wmem == old(wmem)[x17 := seq(vars.key.m0d)];
 {
     assume false;
 }
@@ -54,7 +53,7 @@ procedure compute_rr(ghost vars: mm_vars)
     requires
         mm_vars_safe(vars, wmem, NA, NA, x16, x18, x17);
         to_nat(vars.m_iter.buff) == vars.key.m;
-        to_nat(vars.m0d_iter.buff) == vars.key.m0d;
+        vars.m0d_iter.buff[0] == vars.key.m0d;
 
     ensures
         x16 == old(16);
@@ -90,7 +89,7 @@ procedure modexp_var_0(ghost initial_vars: mm_vars)
         valid_xmem_addr(xmem, 16); // m
         valid_xmem_addr(xmem, 20); // sig
 
-        mm_vars_safe(initial_vars, wmem, NA, NA, xmem[16], xmem[12], xmem[8]);
+        mm_vars_safe(initial_vars, wmem, NA, xmem[20], xmem[16], xmem[12], xmem[8]);
         to_nat(initial_vars.m_iter.buff) == initial_vars.key.m;
 
         xmem[20] != xmem[8];
@@ -99,10 +98,13 @@ procedure modexp_var_0(ghost initial_vars: mm_vars)
     ensures
         x30 == NUM_WORDS;
         x31 == NUM_WORDS - 1;
-        mm_vars_inv(vars, wmem, NA, NA, x16, x18, x17);
 
-        wmem == old(wmem)[x17 := seq(vars.key.m0d)][x18 := wmem[x18]];
+        w31 == 0;
+
         xmem == old(xmem); 
+        mm_vars_inv(vars, wmem, NA, xmem[20], x16, x18, x17);
+        wmem == old(wmem)[x17 := seq(vars.key.m0d)][x18 := wmem[x18]];
+
 {
     vars := initial_vars;
 
@@ -130,8 +132,42 @@ procedure modexp_var_0(ghost initial_vars: mm_vars)
     // lw        x18, 12(x0)
 }
 
+procedure write_to_dmem(ghost iter: iter_t)
+    returns (ghost out_iter: iter_t)
+
+    requires
+        x8 == 4;
+        x30 == NUM_WORDS;
+
+        iter_safe(iter, wmem, x21);
+        seq_len(iter.buff) == NUM_WORDS;
+        iter.index == 0;
+    
+    modifies
+        x8; x21; x30; wdrs; wmem;
+
+{
+    out_iter := iter;
+    // slice := wdrs[4..4+NUM_WORDS];
+
+    while (Loop(x30))
+        invariant
+            x8 == 4 + out_iter.index;
+
+            iter_inv(out_iter, wmem, x21);
+            out_iter.index + loop_ctr == NUM_WORDS;
+            seq_len(out_iter.buff) == NUM_WORDS;
+            // valid_wdr_view(wdrs, out_iter.buff, 4, out_iter.index);
+
+        decreases
+            loop_ctr;
+    {
+        out_iter := bn_sid_safe(x8, false, 0, x21, true, out_iter);
+        addi(x8, x8, 1);
+    }
+}
+
 procedure modexp_var(ghost initial_vars: mm_vars)
-    returns (ghost vars: mm_vars)
 
     {:frame false}
     
@@ -143,52 +179,41 @@ procedure modexp_var(ghost initial_vars: mm_vars)
         valid_xmem_addr(xmem, 12); // rr
         valid_xmem_addr(xmem, 16); // m
         valid_xmem_addr(xmem, 20); // sig
+        valid_xmem_addr(xmem, 28); // out
 
-        mm_vars_safe(initial_vars, wmem, NA, NA, xmem[16], xmem[12], xmem[8]);
-        to_nat(vars.m_iter.buff) == vars.key.m;
+        mm_vars_safe(initial_vars, wmem, NA, xmem[20], xmem[16], xmem[12], xmem[8]);
+        to_nat(initial_vars.m_iter.buff) == initial_vars.key.m;
 
         xmem[20] != xmem[8];
         xmem[20] != xmem[12];
-
 {
-    // vars := modexp_var_0(initial_vars);
+    ghost var vars: mm_vars;
+    ghost var sig_slice: seq(uint256);
 
-//     li(x8, 4);
-//     li(x9, 3);
-//     li(x10, 4);
-//     li(x11, 2);
+    vars := modexp_var_0(initial_vars);
 
-//     lw(x19, 20, x0);
-//     lw(x20, 12, x0);
-//     lw(x21, 28, x0);
+    li(x8, 4);
+    li(x9, 3);
+    li(x10, 4);
+    li(x11, 2);
 
-//     let sig_iter := iter_cons(x19, 0, wmem[x19]);
-//     let rr_iter := iter_cons(x20, 0, wmem[x20]);
+    lw(x19, 20, x0);
+    addi(x20, x18, 0);
+    lw(x21, 28, x0);
 
-//     assert iter_inv(sig_iter, wmem, x19);
-//     assert iter_inv(rr_iter, wmem, x20);
-//     // vars := vars.(x_iter := rr_iter).(y_iter := sig_iter);
+    let sig_iter := iter_cons(x19, 0, wmem[x19]);
+    let rr_iter := iter_cons(x20, 0, wmem[x20]);
 
-//     // assert mm_vars_inv(vars, wmem, x20, x19, x16, x18, x17);
-//     // msig := montmul(vars);
-//     // assert montmul_inv(msig, rr_iter.buff, NUM_WORDS, sig_iter.buff, vars.key);
+    // assert rr_iter == vars.rr_iter;
+    vars := vars.(x_iter := rr_iter).(y_iter := sig_iter);
+    assert mm_vars_inv(vars, wmem, x20, x19, x16, x18, x17);
 
-// //     // /* convert signature to Montgomery domain
-// //     //     out_buf = *x28 = *dmem[28]
-// //     //         <- montmul(*x19, *x20) = montmul(*dptr_sig, *dptr_rr) = sig*R mod M */
-// //     // lw(x19, 20, x0);
-// //     // lw(x20, 12, x0);
-// //     // lw(x21, 28, x0);
-
-// //     // assume mm_vars_inv(vars, wmem, x20, x19, x16, NA, x17);
-
-// //     // let a_slice := montmul(vars);
-// // //   /* store result in dmem starting at dmem[dptr_out] */
-// // //   loop      x30, 2
-// // //     bn.sid    x8, 0(x21++)
-// // //     addi      x8, x8, 1
-// }
-
+    sig_slice := montmul(vars);
+    assert montmul_inv(sig_slice, rr_iter.buff, NUM_WORDS, sig_iter.buff, vars.key);
+    assert rr_iter.buff == rr_iter.buff[..NUM_WORDS];
+    assert cong(to_nat(sig_slice) * vars.key.R, to_nat(rr_iter.buff) * to_nat(sig_iter.buff), vars.key.m);
+    
+}
 
 
 #verbatim

--- a/otbn_model/code/modexp_var.vad
+++ b/otbn_model/code/modexp_var.vad
@@ -42,7 +42,23 @@ ghost procedure modexp_var_inv_lemma_2(
     ghost a_slice: seq(uint256),
     ghost next_a_slice: seq(uint256),
     ghost sig: seq(uint256),
-    ghost key: pub_key)  extern;
+    ghost key: pub_key) extern;
+
+function subb_inv(dst: seq(uint256), carry: uint1, src1: seq(uint256), src2: seq(uint256), index: int) : bool extern;
+
+ghost procedure subb_inv_peri_lemma(
+    ghost dst: seq(uint256),
+    ghost new_carry: uint1,
+    ghost src1: seq(uint256),
+    ghost src2: seq(uint256),
+    ghost old_carry: uint1,
+    ghost index: int) extern;
+
+ghost procedure subb_inv_post_lemma(
+    ghost dst: seq(uint256),
+    ghost carry: uint1,
+    ghost src1: seq(uint256),
+    ghost src2: seq(uint256)) extern;
 
 procedure compute_m0inv(ghost vars: mm_vars)
     requires
@@ -126,7 +142,6 @@ procedure modexp_var_0(ghost vars: mm_vars)
         xmem == old(xmem); 
         mm_vars_inv(vars, wmem, NA, xmem[20], x16, x18, x17);
         wmem == old(wmem)[x17 := seq(vars.key.m0d)][x18 := wmem[x18]];
-
 {
     bn_xor(w31, w31, w31, SFT_DFT);
     assume w31 == 0;
@@ -211,13 +226,184 @@ procedure write_to_dmem(ghost iter: iter_t)
     next_iter := next_iter.(index := 0);
 }
 
+procedure sub_mod(
+    ghost raw_slice: seq(uint256),
+    ghost initial_m_iter: iter_t)
+    returns (ghost adjusted_slice: seq(uint256))
+
+    requires
+        x8 == 4;
+        x9 == 3;
+        x11 == 2;
+        x30 == NUM_WORDS;
+
+        w31 == 0;
+
+        mm_iter_inv(initial_m_iter, wmem, x16);
+        valid_wdr_view(wdrs, raw_slice, 4, NUM_WORDS);
+
+    reads
+        x30;
+        wmem;
+
+    modifies
+        x8; x9; x11; x16; x17;
+        w2; w3; w31;
+        fgroups; wdrs;
+    
+    ensures
+        valid_wdr_view(wdrs, raw_slice, 4, NUM_WORDS);
+        valid_wdr_view(wdrs, adjusted_slice, 16, NUM_WORDS);
+
+        !fgroups.fg0.cf ==> to_nat(raw_slice) - to_nat(initial_m_iter.buff) == to_nat(adjusted_slice);
+        fgroups.fg0.cf ==> to_nat(raw_slice) < to_nat(initial_m_iter.buff);
+{
+    bn_add(w31, w31, w31, SFT_DFT, 0);
+    assert fgroups.fg0.cf == false;
+
+    li(x17, 16);
+    ghost var m_iter := initial_m_iter;
+    adjusted_slice := wdrs[16..16+NUM_WORDS];
+
+    while (Loop(x30))
+        invariant
+            iter_inv(m_iter, wmem, x16);
+            m_iter.base_addr == initial_m_iter.base_addr;
+            m_iter.index == NUM_WORDS - loop_ctr;
+            seq_len(m_iter.buff) == NUM_WORDS;
+
+            x9 == 3;
+            x11 == 2;
+            x8 == 4 + m_iter.index;
+            x17 == 16 + m_iter.index;
+
+            valid_wdr_view(wdrs, raw_slice, 4, NUM_WORDS);
+            valid_wdr_view(wdrs, adjusted_slice, 16, NUM_WORDS);
+
+            subb_inv(adjusted_slice, bool_to_uint1(fgroups.fg0.cf),
+                raw_slice, m_iter.buff, m_iter.index);
+
+        decreases
+            loop_ctr;
+    {
+        ghost var index := m_iter.index;
+        bn_movr(x11, false, x8, true);
+
+        m_iter := bn_lid_safe(x9, false, 0, x16, true, m_iter);
+
+        let old_carry := bool_to_uint1(fgroups.fg0.cf);
+        bn_subb(w2, w2, w3, SFT_DFT, 0);
+        let new_carry := bool_to_uint1(fgroups.fg0.cf);
+
+        bn_movr(x17, true, x11, false);
+        adjusted_slice := adjusted_slice[index := w2];
+
+        assert tuple(w2, new_carry) ==
+            uint256_subb(raw_slice[index], m_iter.buff[index], old_carry);
+
+        subb_inv_peri_lemma(adjusted_slice, new_carry, raw_slice, m_iter.buff, old_carry, index);
+    }
+    
+    let new_carry := bool_to_uint1(fgroups.fg0.cf);
+    subb_inv_post_lemma(adjusted_slice, new_carry, raw_slice, m_iter.buff);
+}
+
+ghost procedure modexp_var_correct_lemma(
+    ghost raw_slice: nat,
+    ghost adjusted_slice: nat,
+    ghost carry: bool,
+    ghost sig: nat,
+    ghost key: pub_key) extern;
+
+function mod(a: int, n: int): int extern;
+
+procedure modexp_write_ouput(
+    ghost raw_slice: seq(uint256),
+    ghost adjusted_slice: seq(uint256),
+    ghost carry: bool,
+    ghost sig: nat,
+    ghost key: pub_key)
+returns (ghost out_iter: iter_t)
+
+    {:frame false }
+
+    requires
+        valid_xmem_addr(xmem, 28); // out
+        valid_wmem_base_addr(wmem, xmem[28], NUM_WORDS);
+
+        NUM_WORDS == x30;
+
+        pub_key_inv(key);
+
+        valid_wdr_view(wdrs, raw_slice, 4, NUM_WORDS);
+        valid_wdr_view(wdrs, adjusted_slice, 16, NUM_WORDS);
+
+        carry == fgroups.fg0.cf;
+        carry ==> to_nat(raw_slice) == mod(power(sig, key.e), key.m);
+        !carry ==> to_nat(adjusted_slice) == mod(power(sig, key.e), key.m);
+    
+    ensures
+        iter_inv(out_iter, wmem, x21);
+        to_nat(out_iter.buff) == mod(power(sig, key.e), key.m);
+{
+    lw(x21, 28, x0);
+    li(x8, 4);
+    li(x9, 2);
+    li(x10, 3);
+    li(x17, 16);
+
+    out_iter := iter_cons(x21, 0, wmem[x21]);
+
+    while (Loop(x30))
+        invariant
+            x9 == 2;
+            x8 == 4 + out_iter.index;
+            x10 == 3;
+            x17 == 16 + out_iter.index;
+            carry == fgroups.fg0.cf;
+
+            iter_inv(out_iter, wmem, x21);
+            out_iter.index + loop_ctr == NUM_WORDS;
+            seq_len(out_iter.buff) == NUM_WORDS;
+
+            valid_wdr_view(wdrs, raw_slice, 4, NUM_WORDS);
+            valid_wdr_view(wdrs, adjusted_slice, 16, NUM_WORDS);
+
+            carry ==> out_iter.buff[..out_iter.index] == raw_slice[..out_iter.index];
+            !carry ==> out_iter.buff[..out_iter.index] == adjusted_slice[..out_iter.index];
+
+        decreases
+            loop_ctr;
+    {
+        let index := out_iter.index;
+        bn_movr(x9, false, x8, true);
+        assert w2 == raw_slice[index];
+
+        bn_movr(x10, false, x17, true);
+        assert w3 == adjusted_slice[index];
+   
+        bn_sel(w2, w2, w3, 0, 0);
+        ghost if (carry) {
+            assert w2 == raw_slice[index];
+        } else {
+            assert w2 == adjusted_slice[index];
+        }
+        out_iter := bn_sid_safe(x9, false, 0, x21, true, out_iter);
+    }
+
+    assert out_iter.buff == out_iter.buff[..NUM_WORDS];
+    assert raw_slice == raw_slice[..out_iter.index];
+    assert adjusted_slice == adjusted_slice[..out_iter.index];
+}
+
 procedure modexp_var(
     ghost initial_vars: mm_vars)
+    returns (ghost out_iter: iter_t)
 
     {:frame false}
     
     requires
-        valid_xmem_addr(xmem, 0);  //
+        valid_xmem_addr(xmem, 0);  // e'
         xmem[0] == initial_vars.key.e';
 
         valid_xmem_addr(xmem, 4);
@@ -229,8 +415,11 @@ procedure modexp_var(
         valid_xmem_addr(xmem, 20); // sig
         valid_xmem_addr(xmem, 28); // out
 
-        mm_vars_safe(initial_vars, wmem, NA, xmem[20], xmem[16], xmem[12], xmem[8]);
-        
+        mm_vars_safe(initial_vars, wmem, 
+            NA, xmem[20], xmem[16], xmem[12], xmem[8]);
+
+        to_nat(wmem[xmem[20]]) == initial_vars.key.sig;
+
         valid_wmem_base_addr(wmem, xmem[28], NUM_WORDS);
 
         to_nat(initial_vars.m_iter.buff) == initial_vars.key.m;
@@ -242,6 +431,13 @@ procedure modexp_var(
         xmem[28] != xmem[12];
         xmem[28] != xmem[16];
         xmem[28] != xmem[20];
+
+    ensures
+        // out_iter contains a valid view of memory
+        iter_inv(out_iter, wmem, x21);
+        // out_iter contains the right value
+        let key := initial_vars.key in 
+        to_nat(out_iter.buff) == mod(power(key.sig, key.e), key.m);
 {
     ghost var a_slice: seq(uint256);
     
@@ -263,7 +459,7 @@ procedure modexp_var(
     a_slice := montmul(vars);
 
     let out_addr := xmem[28];
-    ghost var out_iter := iter_cons(out_addr, 0, wmem[out_addr]);
+    out_iter := iter_cons(out_addr, 0, wmem[out_addr]);
     out_iter := write_to_dmem(out_iter);
 
     vars := vars.(x_iter := out_iter).(y_iter := out_iter);
@@ -271,7 +467,6 @@ procedure modexp_var(
     modexp_var_inv_lemma_0(a_slice, rr_iter.buff, sig_iter.buff, vars.key);
 
     ghost var i : nat := 0;
-
     assert x29 == vars.key.e';
 
     while (Loop(x29))
@@ -284,6 +479,8 @@ procedure modexp_var(
             x31 == NUM_WORDS - 1;
 
             w31 == 0;
+
+            initial_vars.key == vars.key;
 
             mm_iter_inv(sig_iter, wmem, sig_iter.base_addr);
             valid_xmem_addr(xmem, 20);
@@ -298,7 +495,8 @@ procedure modexp_var(
             out_iter.buff == a_slice;
 
             mm_vars_inv(vars, wmem, out_addr, out_addr, x16, NA, x17);
-            modexp_var_inv(to_nat(a_slice), to_nat(sig_iter.buff), i, vars.key);
+            to_nat(sig_iter.buff) == vars.key.sig;
+            modexp_var_inv(to_nat(a_slice), vars.key.sig, i, vars.key);
 
             out_addr != x16;
             out_addr != x17;
@@ -319,7 +517,7 @@ procedure modexp_var(
         
         vars := vars.(x_iter := out_iter).(y_iter := out_iter);
 
-        modexp_var_inv_lemma_1(prev_a_slice, a_slice, to_nat(sig_iter.buff), i, vars.key);
+        modexp_var_inv_lemma_1(prev_a_slice, a_slice, vars.key.sig, i, vars.key);
     
         i := i + 1;
     }
@@ -333,6 +531,15 @@ procedure modexp_var(
     a_slice := montmul(vars);
 
     modexp_var_inv_lemma_2(prev_a_slice, a_slice, sig_iter.buff, vars.key);
+
+    ghost var raw_slice := wdrs[4..4+NUM_WORDS];
+    let adjusted_slice := sub_mod(raw_slice, vars.m_iter);
+    
+    let carry := fgroups.fg0.cf;
+    modexp_var_correct_lemma(to_nat(raw_slice), to_nat(adjusted_slice), carry,
+        vars.key.sig, vars.key);
+
+    out_iter := modexp_write_ouput(raw_slice, adjusted_slice, carry, vars.key.sig, vars.key);
 }
 
 

--- a/otbn_model/code/modexp_var.vad
+++ b/otbn_model/code/modexp_var.vad
@@ -156,12 +156,13 @@ procedure write_to_dmem(ghost iter: iter_t)
         x30; wdrs;
 
     ensures
-        iter_inv(next_iter, wmem, x21);
-
+        iter_inv(next_iter, wmem, iter.base_addr);
         next_iter.base_addr == iter.base_addr;
-        wmem == old(wmem)[next_iter.base_addr := next_iter.buff];
-
+        seq_len(next_iter.buff) == NUM_WORDS;
         next_iter.buff == wdrs[4..4+NUM_WORDS];
+        iter.index == 0;
+
+        wmem == old(wmem)[next_iter.base_addr := next_iter.buff];
 {
     next_iter := iter;
 
@@ -190,6 +191,8 @@ procedure write_to_dmem(ghost iter: iter_t)
 
         assert next_iter.buff[index] == wdrs[4+index];
     }
+
+    next_iter := next_iter.(index := 0);
 }
 
 procedure modexp_var(ghost initial_vars: mm_vars)
@@ -197,7 +200,7 @@ procedure modexp_var(ghost initial_vars: mm_vars)
     {:frame false}
     
     requires
-        valid_xmem_addr(xmem, 0);  // e
+        valid_xmem_addr(xmem, 0);  //
         xmem[0] == initial_vars.key.e;
 
         valid_xmem_addr(xmem, 4);
@@ -236,18 +239,16 @@ procedure modexp_var(ghost initial_vars: mm_vars)
     addi(x20, x18, 0);
     lw(x21, 28, x0);
 
-
     let sig_iter := iter_cons(x19, 0, wmem[x19]);
     let rr_iter := iter_cons(x20, 0, wmem[x20]);
 
     ghost var vars := initial_vars.(x_iter := rr_iter).(y_iter := sig_iter);
     a_slice := montmul(vars);
 
-    ghost var out_iter := iter_cons(x21, 0, wmem[x21]);
+    let out_addr := xmem[28];
+    ghost var out_iter := iter_cons(out_addr, 0, wmem[out_addr]);
     out_iter := write_to_dmem(out_iter);
 
-    let out_addr := xmem[28];
-    out_iter := iter_cons(out_addr, 0, wmem[out_addr]);
     vars := vars.(x_iter := out_iter).(y_iter := out_iter);
 
     while (Loop(x29))
@@ -262,9 +263,16 @@ procedure modexp_var(ghost initial_vars: mm_vars)
             w31 == 0;
 
             valid_xmem_addr(xmem, 28);
-            xmem[28] == out_iter.base_addr;
+            xmem[28] == out_addr;
+
+            iter_safe(out_iter, wmem, out_addr);
+            seq_len(out_iter.buff) == NUM_WORDS;
+            out_iter.index == 0;
 
             mm_vars_inv(vars, wmem, out_addr, out_addr, x16, NA, x17);
+
+            out_addr != x16;
+            out_addr != x17;
 
         decreases
             loop_ctr;
@@ -274,6 +282,11 @@ procedure modexp_var(ghost initial_vars: mm_vars)
         lw(x21, 28, x0);
 
         a_slice := montmul(vars);
+
+        out_iter := write_to_dmem(out_iter);
+        
+        assert iter_safe(out_iter, wmem, out_addr);
+        vars := vars.(x_iter := out_iter).(y_iter := out_iter);
     }
 
     // assert x29 == vars.key.e;

--- a/otbn_model/code/modexp_var.vad
+++ b/otbn_model/code/modexp_var.vad
@@ -2,13 +2,8 @@ include "decls.vad"
 include "montmul.vad"
 
 #verbatim
-include "../code/vale.dfy"
-include "../spec/rsa_ops.dfy"
-include "decls.dfy"
-
 include "montmul.dfy"
-// include "../code/mont_loop_lemmas.dfy"
-// include "../code/montmul_lemmas.dfy"
+include "../code/modexp_var_lemmas.dfy"
 
 module modexp_var {
 
@@ -24,9 +19,24 @@ import opened congruences
 import opened mont_loop
 import opened montmul
 import opened mont_loop_lemmas
-// import opened montmul_lemmas
+import opened modexp_var_lemmas
 
 #endverbatim
+
+function modexp_var_inv(a: nat, sig: nat, i: nat, key: pub_key): bool extern;
+
+ghost procedure modexp_var_inv_lemma_0(
+    ghost a_slice: seq(uint256),
+    ghost rr: seq(uint256),
+    ghost sig: seq(uint256),
+    ghost key: pub_key) extern;
+
+ghost procedure modexp_var_inv_lemma_1(
+    ghost a_slice: seq(uint256),
+    ghost next_a_slice: seq(uint256),
+    ghost sig: nat,
+    ghost i: nat,
+    ghost key: pub_key) extern;
 
 procedure compute_m0inv(ghost vars: mm_vars)
     requires
@@ -82,8 +92,8 @@ procedure modexp_var_0(ghost vars: mm_vars)
 
     requires
 
-        valid_xmem_addr(xmem, 0);  // e
-        xmem[0] == vars.key.e;
+        valid_xmem_addr(xmem, 0);  // e'
+        xmem[0] == vars.key.e';
 
         valid_xmem_addr(xmem, 4);
         xmem[4] == NUM_WORDS;
@@ -101,7 +111,7 @@ procedure modexp_var_0(ghost vars: mm_vars)
 
     ensures
     
-        x29 == vars.key.e;
+        x29 == vars.key.e';
         x30 == NUM_WORDS;
         x31 == NUM_WORDS - 1;
 
@@ -195,13 +205,14 @@ procedure write_to_dmem(ghost iter: iter_t)
     next_iter := next_iter.(index := 0);
 }
 
-procedure modexp_var(ghost initial_vars: mm_vars)
+procedure modexp_var(
+    ghost initial_vars: mm_vars)
 
     {:frame false}
     
     requires
         valid_xmem_addr(xmem, 0);  //
-        xmem[0] == initial_vars.key.e;
+        xmem[0] == initial_vars.key.e';
 
         valid_xmem_addr(xmem, 4);
         xmem[4] == NUM_WORDS;
@@ -251,6 +262,12 @@ procedure modexp_var(ghost initial_vars: mm_vars)
 
     vars := vars.(x_iter := out_iter).(y_iter := out_iter);
 
+    modexp_var_inv_lemma_0(a_slice, rr_iter.buff, sig_iter.buff, vars.key);
+
+    ghost var i : nat := 0;
+
+    assert x29 == vars.key.e';
+
     while (Loop(x29))
         invariant
             x9 == 3;
@@ -262,17 +279,25 @@ procedure modexp_var(ghost initial_vars: mm_vars)
 
             w31 == 0;
 
+            mm_iter_inv(sig_iter, wmem, sig_iter.base_addr);
+            valid_xmem_addr(xmem, 20);
+            xmem[20] == sig_iter.base_addr;
+
             valid_xmem_addr(xmem, 28);
             xmem[28] == out_addr;
 
             iter_safe(out_iter, wmem, out_addr);
             seq_len(out_iter.buff) == NUM_WORDS;
             out_iter.index == 0;
+            out_iter.buff == a_slice;
 
             mm_vars_inv(vars, wmem, out_addr, out_addr, x16, NA, x17);
+            modexp_var_inv(to_nat(a_slice), to_nat(sig_iter.buff), i, vars.key);
 
             out_addr != x16;
             out_addr != x17;
+
+            i + loop_ctr == vars.key.e'; 
 
         decreases
             loop_ctr;
@@ -281,23 +306,31 @@ procedure modexp_var(ghost initial_vars: mm_vars)
         lw(x20, 28, x0);
         lw(x21, 28, x0);
 
+        let prev_a_slice := a_slice;
         a_slice := montmul(vars);
 
         out_iter := write_to_dmem(out_iter);
         
-        assert iter_safe(out_iter, wmem, out_addr);
         vars := vars.(x_iter := out_iter).(y_iter := out_iter);
+
+        modexp_var_inv_lemma_1(prev_a_slice, a_slice, to_nat(sig_iter.buff), i, vars.key);
+    
+        i := i + 1;
     }
 
-    // assert x29 == vars.key.e;
+    lw(x19, 20, x0);
+    lw(x20, 28, x0);
+    lw(x21, 28, x0);
+    let prev_a_slice := a_slice;
+
+    vars := vars.(x_iter := out_iter).(y_iter := sig_iter);
+    a_slice := montmul(vars);
+
+    
+
 }
 
 
 #verbatim
 }
 #endverbatim
-
-
-    // assert montmul_inv(a_slice, rr_iter.buff, NUM_WORDS, sig_iter.buff, vars.key);
-    // assert rr_iter.buff == rr_iter.buff[..NUM_WORDS];
-    // assert cong(to_nat(a_slice) * vars.key.R, to_nat(rr_iter.buff) * to_nat(sig_iter.buff), vars.key.m);

--- a/otbn_model/code/modexp_var.vad
+++ b/otbn_model/code/modexp_var.vad
@@ -59,6 +59,7 @@ procedure compute_rr(ghost vars: mm_vars)
         x16 == old(16);
         x18 == old(18);
         x17 == old(17);
+        x29 == old(x29);
         x30 == old(x30);
         x31 == old(x31);
 
@@ -75,12 +76,15 @@ procedure compute_rr(ghost vars: mm_vars)
     assume false;
 }
 
-procedure modexp_var_0(ghost initial_vars: mm_vars)
-    returns (ghost vars: mm_vars)
+procedure modexp_var_0(ghost vars: mm_vars)
 
     {:frame false}
 
     requires
+
+        valid_xmem_addr(xmem, 0);  // e
+        xmem[0] == vars.key.e;
+
         valid_xmem_addr(xmem, 4);
         xmem[4] == NUM_WORDS;
 
@@ -89,13 +93,15 @@ procedure modexp_var_0(ghost initial_vars: mm_vars)
         valid_xmem_addr(xmem, 16); // m
         valid_xmem_addr(xmem, 20); // sig
 
-        mm_vars_safe(initial_vars, wmem, NA, xmem[20], xmem[16], xmem[12], xmem[8]);
-        to_nat(initial_vars.m_iter.buff) == initial_vars.key.m;
+        mm_vars_safe(vars, wmem, NA, xmem[20], xmem[16], xmem[12], xmem[8]);
+        to_nat(vars.m_iter.buff) == vars.key.m;
 
         xmem[20] != xmem[8];
         xmem[20] != xmem[12];
 
     ensures
+    
+        x29 == vars.key.e;
         x30 == NUM_WORDS;
         x31 == NUM_WORDS - 1;
 
@@ -106,8 +112,6 @@ procedure modexp_var_0(ghost initial_vars: mm_vars)
         wmem == old(wmem)[x17 := seq(vars.key.m0d)][x18 := wmem[x18]];
 
 {
-    vars := initial_vars;
-
     bn_xor(w31, w31, w31, SFT_DFT);
     assume w31 == 0;
 
@@ -121,6 +125,8 @@ procedure modexp_var_0(ghost initial_vars: mm_vars)
     lw(x17, 8, x0);
 
     lw(x18, 12, x0);
+
+    lw(x29, 0, x0);
 
     // TODO: figure out if these will be pre-computed
     compute_m0inv(vars);
@@ -144,10 +150,10 @@ procedure write_to_dmem(ghost iter: iter_t)
         iter.index == 0;
     
     modifies
-        x8; x21; x30; wmem;
+        x8; x21; wmem;
     
     reads
-        wdrs;
+        x30; wdrs;
 
     ensures
         iter_inv(next_iter, wmem, x21);
@@ -191,6 +197,9 @@ procedure modexp_var(ghost initial_vars: mm_vars)
     {:frame false}
     
     requires
+        valid_xmem_addr(xmem, 0);  // e
+        xmem[0] == initial_vars.key.e;
+
         valid_xmem_addr(xmem, 4);
         xmem[4] == NUM_WORDS;
 
@@ -214,10 +223,9 @@ procedure modexp_var(ghost initial_vars: mm_vars)
         xmem[28] != xmem[16];
         xmem[28] != xmem[20];
 {
-    ghost var vars: mm_vars;
-    ghost var sig_slice: seq(uint256);
-
-    vars := modexp_var_0(initial_vars);
+    ghost var a_slice: seq(uint256);
+    
+    modexp_var_0(initial_vars);
 
     li(x8, 4);
     li(x9, 3);
@@ -228,28 +236,55 @@ procedure modexp_var(ghost initial_vars: mm_vars)
     addi(x20, x18, 0);
     lw(x21, 28, x0);
 
-    // ghost var out_iter := iter_cons(x21, 0, wmem[x21]);
+
     let sig_iter := iter_cons(x19, 0, wmem[x19]);
     let rr_iter := iter_cons(x20, 0, wmem[x20]);
 
+    ghost var vars := initial_vars.(x_iter := rr_iter).(y_iter := sig_iter);
+    a_slice := montmul(vars);
 
-    // assert rr_iter == vars.rr_iter;
-    vars := vars.(x_iter := rr_iter).(y_iter := sig_iter);
-    assert mm_vars_inv(vars, wmem, x20, x19, x16, x18, x17);
-
-    sig_slice := montmul(vars);
     ghost var out_iter := iter_cons(x21, 0, wmem[x21]);
+    out_iter := write_to_dmem(out_iter);
 
-    // assert montmul_inv(sig_slice, rr_iter.buff, NUM_WORDS, sig_iter.buff, vars.key);
-    // assert rr_iter.buff == rr_iter.buff[..NUM_WORDS];
-    // assert cong(to_nat(sig_slice) * vars.key.R, to_nat(rr_iter.buff) * to_nat(sig_iter.buff), vars.key.m);
-    
-    // out_iter := write_to_dmem(out_iter);
+    let out_addr := xmem[28];
+    out_iter := iter_cons(out_addr, 0, wmem[out_addr]);
+    vars := vars.(x_iter := out_iter).(y_iter := out_iter);
 
-    // assert mm_vars_inv(vars, wmem, NA, NA, x16, x18, x17);
+    while (Loop(x29))
+        invariant
+            x9 == 3;
+            x10 == 4;
+            x11 == 2;
+        
+            x30 == NUM_WORDS;
+            x31 == NUM_WORDS - 1;
+
+            w31 == 0;
+
+            valid_xmem_addr(xmem, 28);
+            xmem[28] == out_iter.base_addr;
+
+            mm_vars_inv(vars, wmem, out_addr, out_addr, x16, NA, x17);
+
+        decreases
+            loop_ctr;
+    {
+        lw(x19, 28, x0);
+        lw(x20, 28, x0);
+        lw(x21, 28, x0);
+
+        a_slice := montmul(vars);
+    }
+
+    // assert x29 == vars.key.e;
 }
 
 
 #verbatim
 }
 #endverbatim
+
+
+    // assert montmul_inv(a_slice, rr_iter.buff, NUM_WORDS, sig_iter.buff, vars.key);
+    // assert rr_iter.buff == rr_iter.buff[..NUM_WORDS];
+    // assert cong(to_nat(a_slice) * vars.key.R, to_nat(rr_iter.buff) * to_nat(sig_iter.buff), vars.key.m);

--- a/otbn_model/code/modexp_var.vad
+++ b/otbn_model/code/modexp_var.vad
@@ -1,0 +1,181 @@
+include "decls.vad"
+include "montmul.vad"
+
+#verbatim
+include "../code/vale.dfy"
+include "../spec/rsa_ops.dfy"
+include "decls.dfy"
+
+include "montmul.dfy"
+// include "../code/mont_loop_lemmas.dfy"
+// include "../code/montmul_lemmas.dfy"
+
+module modexp_var {
+
+import opened bv_ops
+import opened vt_ops
+import opened rsa_ops
+import opened vt_consts
+import opened vt_vale
+import opened vt_decls
+import opened powers
+import opened congruences
+
+import opened mont_loop
+import opened montmul
+import opened mont_loop_lemmas
+// import opened montmul_lemmas
+
+#endverbatim
+
+procedure compute_m0inv(ghost vars: mm_vars)
+    requires
+        mm_vars_inv(vars, wmem, NA, NA, x16, NA, NA);
+        valid_wmem_base_addr(wmem, x17, 1);
+
+    modifies
+        fgroups; wmem;
+        x8; x17; w0; w1; w28; w29;
+    
+    reads
+        xmem; x16;
+
+    ensures
+        x17 == old(17);
+        mm_vars_inv(vars, wmem, NA, NA, x16, NA, x17);
+        wmem == old(wmem)[x17 := seq(vars.key.m0d)];
+{
+    assume false;
+}
+
+procedure compute_rr(ghost vars: mm_vars)
+    {: frame false}
+
+    requires
+        mm_vars_inv(vars, wmem, NA, NA, x16, NA, x17);
+        valid_wmem_base_addr(wmem, x18, NUM_WORDS);
+
+    ensures
+        x16 == old(16);
+        x18 == old(18);
+        x17 == old(17);
+        x30 == old(x30);
+        x31 == old(x31);
+
+        w31 == old(w31);
+
+        mm_vars_inv(vars, wmem, NA, NA, x16, x18, x17);
+        wmem == old(wmem)[x18 := wmem[x18]];
+        xmem == old(xmem);
+{
+    assume false;
+}
+
+procedure modexp_var_0(ghost vars: mm_vars)
+    returns (ghost msig: seq(uint256))
+
+    {:frame false}
+
+    requires
+        valid_xmem_addr(xmem, 4);
+        xmem[4] == NUM_WORDS;
+
+        valid_xmem_addr(xmem, 16); // m
+
+        valid_xmem_addr(xmem, 8);  // m0d
+        valid_wmem_base_addr(wmem, xmem[8], 1);
+
+        valid_xmem_addr(xmem, 12); // rr
+        valid_wmem_base_addr(wmem, xmem[12], NUM_WORDS);
+
+        valid_xmem_addr(xmem, 20); // sig
+        valid_wmem_base_addr(wmem, xmem[20], NUM_WORDS);
+
+        valid_xmem_addr(xmem, 28); // output
+        valid_wmem_base_addr(wmem, xmem[28], NUM_WORDS);
+
+        xmem[20] != xmem[8];
+        xmem[20] != xmem[12];
+
+        mm_vars_inv(vars, wmem, NA, NA, xmem[16], NA, NA);
+
+    ensures
+        // x30 == NUM_WORDS;
+        // x31 == NUM_WORDS - 1;
+        // mm_vars_inv(vars, wmem, NA, NA, x16, x18, x17);
+{
+    ghost var mvars := vars;
+
+    bn_xor(w31, w31, w31, SFT_DFT);
+    assume w31 == 0;
+
+    lw(x30, 4, x0);
+
+    addi(x31, x0, 1); // TODO: use one instruction instead
+    sub(x31, x30, x31);
+
+    lw(x16, 16, x0);
+
+    lw(x17, 8, x0);
+
+    lw(x18, 12, x0);
+
+    // TODO: figure out if these will be pre-computed
+    compute_m0inv(mvars);
+    compute_rr(mvars);
+
+    assert valid_wmem_base_addr(wmem, xmem[20], NUM_WORDS);
+
+    // TODO: it is easier to restore pointers in the procedures
+    // lw        x16, 16(x0)
+    // lw        x17, 8(x0)
+    // lw        x18, 12(x0)
+
+    li(x8, 4);
+    li(x9, 3);
+    li(x10, 4);
+    li(x11, 2);
+
+    lw(x19, 20, x0);
+    lw(x20, 12, x0);
+    lw(x21, 28, x0);
+
+    let sig_iter := iter_cons(x19, 0, wmem[x19]);
+    let rr_iter := iter_cons(x20, 0, wmem[x20]);
+    // assert iter_inv(sig_iter, wmem, x19);
+    // assert iter_inv(rr_iter, wmem, x20);
+    mvars := mvars.(x_iter := rr_iter).(y_iter := sig_iter);
+
+    assert mm_vars_inv(mvars, wmem, x20, x19, x16, x18, x17);
+    msig := montmul(mvars);
+    assert montmul_inv(msig, mvars.x_iter.buff, NUM_WORDS, mvars.y_iter.buff, mvars.key);
+    // assert cong(to_nat(msig) * pow_B256(NUM_WORDS), to_nat(sig_iter.buff[..NUM_WORDS]) * to_nat(rr_iter.buff), mvars.key.m);
+}
+
+procedure modexp_var(ghost vars: mm_vars)
+//     {:frame false}
+
+{
+
+
+//     // /* convert signature to Montgomery domain
+//     //     out_buf = *x28 = *dmem[28]
+//     //         <- montmul(*x19, *x20) = montmul(*dptr_sig, *dptr_rr) = sig*R mod M */
+//     // lw(x19, 20, x0);
+//     // lw(x20, 12, x0);
+//     // lw(x21, 28, x0);
+
+//     // assume mm_vars_inv(vars, wmem, x20, x19, x16, NA, x17);
+
+//     // let a_slice := montmul(vars);
+// //   /* store result in dmem starting at dmem[dptr_out] */
+// //   loop      x30, 2
+// //     bn.sid    x8, 0(x21++)
+// //     addi      x8, x8, 1
+}
+
+
+
+#verbatim
+}
+#endverbatim

--- a/otbn_model/code/modexp_var.vad
+++ b/otbn_model/code/modexp_var.vad
@@ -133,7 +133,7 @@ procedure modexp_var_0(ghost initial_vars: mm_vars)
 }
 
 procedure write_to_dmem(ghost iter: iter_t)
-    returns (ghost out_iter: iter_t)
+    returns (ghost next_iter: iter_t)
 
     requires
         x8 == 4;
@@ -144,26 +144,45 @@ procedure write_to_dmem(ghost iter: iter_t)
         iter.index == 0;
     
     modifies
-        x8; x21; x30; wdrs; wmem;
+        x8; x21; x30; wmem;
+    
+    reads
+        wdrs;
 
+    ensures
+        iter_inv(next_iter, wmem, x21);
+
+        next_iter.base_addr == iter.base_addr;
+        wmem == old(wmem)[next_iter.base_addr := next_iter.buff];
+
+        next_iter.buff == wdrs[4..4+NUM_WORDS];
 {
-    out_iter := iter;
-    // slice := wdrs[4..4+NUM_WORDS];
+    next_iter := iter;
 
     while (Loop(x30))
         invariant
-            x8 == 4 + out_iter.index;
+            x8 == 4 + next_iter.index;
 
-            iter_inv(out_iter, wmem, x21);
-            out_iter.index + loop_ctr == NUM_WORDS;
-            seq_len(out_iter.buff) == NUM_WORDS;
-            // valid_wdr_view(wdrs, out_iter.buff, 4, out_iter.index);
+            iter_inv(next_iter, wmem, x21);
+            next_iter.index + loop_ctr == NUM_WORDS;
+            seq_len(next_iter.buff) == NUM_WORDS;
+
+            next_iter.buff[..next_iter.index] == wdrs[4..4+next_iter.index];
+            wdrs == old(wdrs);
+
+            next_iter.base_addr == iter.base_addr;
+            wmem == old(wmem)[next_iter.base_addr := next_iter.buff];
 
         decreases
             loop_ctr;
-    {
-        out_iter := bn_sid_safe(x8, false, 0, x21, true, out_iter);
+    {   
+        ghost var index := next_iter.index;
+        ghost var last_iter := next_iter;
+
+        next_iter := bn_sid_safe(x8, false, 0, x21, true, next_iter);
         addi(x8, x8, 1);
+
+        assert next_iter.buff[index] == wdrs[4+index];
     }
 }
 
@@ -182,10 +201,18 @@ procedure modexp_var(ghost initial_vars: mm_vars)
         valid_xmem_addr(xmem, 28); // out
 
         mm_vars_safe(initial_vars, wmem, NA, xmem[20], xmem[16], xmem[12], xmem[8]);
+        
+        valid_wmem_base_addr(wmem, xmem[28], NUM_WORDS);
+
         to_nat(initial_vars.m_iter.buff) == initial_vars.key.m;
 
         xmem[20] != xmem[8];
         xmem[20] != xmem[12];
+
+        xmem[28] != xmem[8];
+        xmem[28] != xmem[12];
+        xmem[28] != xmem[16];
+        xmem[28] != xmem[20];
 {
     ghost var vars: mm_vars;
     ghost var sig_slice: seq(uint256);
@@ -201,18 +228,25 @@ procedure modexp_var(ghost initial_vars: mm_vars)
     addi(x20, x18, 0);
     lw(x21, 28, x0);
 
+    // ghost var out_iter := iter_cons(x21, 0, wmem[x21]);
     let sig_iter := iter_cons(x19, 0, wmem[x19]);
     let rr_iter := iter_cons(x20, 0, wmem[x20]);
+
 
     // assert rr_iter == vars.rr_iter;
     vars := vars.(x_iter := rr_iter).(y_iter := sig_iter);
     assert mm_vars_inv(vars, wmem, x20, x19, x16, x18, x17);
 
     sig_slice := montmul(vars);
-    assert montmul_inv(sig_slice, rr_iter.buff, NUM_WORDS, sig_iter.buff, vars.key);
-    assert rr_iter.buff == rr_iter.buff[..NUM_WORDS];
-    assert cong(to_nat(sig_slice) * vars.key.R, to_nat(rr_iter.buff) * to_nat(sig_iter.buff), vars.key.m);
+    ghost var out_iter := iter_cons(x21, 0, wmem[x21]);
+
+    // assert montmul_inv(sig_slice, rr_iter.buff, NUM_WORDS, sig_iter.buff, vars.key);
+    // assert rr_iter.buff == rr_iter.buff[..NUM_WORDS];
+    // assert cong(to_nat(sig_slice) * vars.key.R, to_nat(rr_iter.buff) * to_nat(sig_iter.buff), vars.key.m);
     
+    // out_iter := write_to_dmem(out_iter);
+
+    // assert mm_vars_inv(vars, wmem, NA, NA, x16, x18, x17);
 }
 
 

--- a/otbn_model/code/modexp_var_lemmas.dfy
+++ b/otbn_model/code/modexp_var_lemmas.dfy
@@ -1,0 +1,147 @@
+include "../spec/rsa_ops.dfy"
+include "montmul_lemmas.dfy"
+
+module modexp_var_lemmas {
+    import opened bv_ops
+    import opened vt_ops
+    import opened rsa_ops
+    import opened vt_consts
+    import opened powers
+    import opened congruences
+    import opened mont_loop_lemmas
+    import opened montmul_lemmas
+
+    predicate modexp_var_inv(
+        a: nat,
+        sig: nat,
+        i: nat,
+        key: pub_key)
+        requires key.m != 0;
+    {
+        cong(a, power(sig, power(2, i)) * key.R, key.m)
+    }
+
+    lemma modexp_var_inv_lemma_0(
+        a_slice: seq<uint256>,
+        rr: seq<uint256>,
+        sig: seq<uint256>,
+        key: pub_key)
+
+        requires montmul_inv(a_slice, rr, NUM_WORDS, sig, key);
+        requires to_nat(rr) == key.RR;
+        ensures modexp_var_inv(to_nat(a_slice), to_nat(sig), 0, key);
+    {
+        var m := key.m;
+        var a := to_nat(a_slice);
+        var s := to_nat(sig);
+
+        assert cong(key.RR * key.R_INV, key.R, m) by {
+            assert cong(key.R * key.R * key.R_INV, key.R, m) by {
+                r_r_inv_cancel_lemma(key.R, key);
+            }
+            assert cong(key.RR * key.R_INV, key.R * key.R * key.R_INV, m) by {
+                assert cong(key.RR, key.R * key.R, m);
+                cong_mul_lemma_1(key.RR, key.R * key.R, key.R_INV, m);
+            }
+            reveal cong();
+        }
+
+        assert cong(a, s * key.R, m) by {
+            assert cong(key.RR * key.R_INV * s, key.R * s, m) by {
+                cong_mul_lemma_1(key.RR * key.R_INV, key.R, s, m);
+            }
+            assert cong(a, key.RR * key.R_INV * s, m) by {
+                montmul_inv_lemma_1(a_slice, rr, sig, key);
+            }
+            reveal cong();
+        }
+        
+        reveal power();
+    }
+
+    lemma modexp_var_inv_lemma_1(
+        a_slice: seq<uint256>,
+        next_a_slice: seq<uint256>,
+        sig: nat,
+        i: nat,
+        key: pub_key)
+
+        requires montmul_inv(next_a_slice, a_slice, NUM_WORDS, a_slice, key);
+        requires modexp_var_inv(to_nat(a_slice), sig, i, key);
+        ensures modexp_var_inv(to_nat(next_a_slice), sig, i + 1, key);
+    {
+        var m := key.m;
+        var a := to_nat(a_slice);
+        var next_a := to_nat(next_a_slice);
+        var next_goal := power(sig, power(2, i + 1)) * key.R;
+
+        assert cong(a, power(sig, power(2, i)) * key.R, m);
+        
+        calc ==> {
+            cong(a, power(sig, power(2, i)) * key.R, m);
+                { cong_mul_lemma_2(a, power(sig, power(2, i)) * key.R, 
+                    a, power(sig, power(2, i)) * key.R, m); }
+            cong(a * a, power(sig, power(2, i)) * key.R * power(sig, power(2, i)) * key.R, m);
+                { power_same_base_lemma(sig, power(2, i), power(2, i)); }
+            cong(a * a, power(sig, power(2, i) + power(2, i)) * key.R * key.R, m);
+            cong(a * a, power(sig, power(2, i) * 2) * key.R * key.R, m);
+                { power_add_one_lemma(2, i); }
+            cong(a * a, next_goal * key.R, m);
+                { cong_mul_lemma_1(a * a, next_goal * key.R, key.R_INV, m); }
+            cong(a * a * key.R_INV, next_goal * key.R * key.R_INV, m);
+                {
+                    assert cong(next_a, a * a * key.R_INV, m) by {
+                        montmul_inv_lemma_1(next_a_slice, a_slice, a_slice, key);
+                    }
+                    cong_trans_lemma(next_a, a * a * key.R_INV, next_goal * key.R * key.R_INV, m);
+                }
+            cong(next_a, next_goal * key.R_INV * key.R, m);
+                { r_r_inv_cancel_lemma_2(next_a, next_goal, key); }
+            cong(next_a, next_goal, m);
+        }
+
+    }
+
+    lemma modexp_var_inv_lemma_2(
+        a_slice: seq<uint256>,
+        next_a_slice: seq<uint256>,
+        sig: seq<uint256>,
+        key: pub_key)
+
+        requires montmul_inv(next_a_slice, a_slice, NUM_WORDS, sig, key);
+        requires modexp_var_inv(to_nat(a_slice), to_nat(sig), key.e', key);
+        ensures cong(to_nat(next_a_slice), power(to_nat(sig), key.e), key.m);
+    {
+        var m := key.m;
+        var a := to_nat(a_slice);
+        var next_a := to_nat(next_a_slice);
+        var s := to_nat(sig);
+        var cur := power(s, power(2, key.e'));
+
+        assert cong(a, cur * key.R, m);
+
+        calc ==> {
+            cong(a, cur * key.R, m);
+                { cong_mul_lemma_1(a, cur * key.R, s * key.R_INV, m); }
+            cong(a * (s * key.R_INV), (cur * key.R) * (s * key.R_INV), m);
+                {
+                    assert a * (s * key.R_INV) == a * s * key.R_INV;
+                    assert (cur * key.R) * (s * key.R_INV) == cur * key.R * s * key.R_INV;
+                }
+            cong(a * s * key.R_INV, cur * key.R * s * key.R_INV, m);
+                {
+                    assert cong(next_a, a * s * key.R_INV, m) by {
+                        montmul_inv_lemma_1(next_a_slice, a_slice, sig, key);
+                    }
+                    cong_trans_lemma(next_a, a * s * key.R_INV, cur * key.R * s * key.R_INV, m);
+                }
+            cong(next_a, cur * key.R * s * key.R_INV, m);
+                { r_r_inv_cancel_lemma_2(next_a, cur * s, key); }
+            cong(next_a, cur * s, m);
+                { power_add_one_lemma(s, power(2, key.e')); }
+            cong(next_a, power(s, power(2, key.e') + 1), m);
+            cong(next_a, power(s, key.e), m);
+            cong(to_nat(next_a_slice), power(to_nat(sig), key.e), m);
+        }
+    }
+}

--- a/otbn_model/code/modexp_var_lemmas.dfy
+++ b/otbn_model/code/modexp_var_lemmas.dfy
@@ -11,6 +11,65 @@ module modexp_var_lemmas {
     import opened mont_loop_lemmas
     import opened montmul_lemmas
 
+    predicate subb_inv(
+        dst: seq<uint256>,
+        carry: uint1,
+        src1: seq<uint256>,
+        src2: seq<uint256>,
+        index: nat)
+
+    requires |dst| == |src1| == |src2|;
+    requires index <= |src1|;
+    {
+        (dst[..index], carry)
+            == seq_subb(src1[..index], src2[..index])
+    }
+
+    lemma subb_inv_peri_lemma(
+        dst: seq<uint256>,
+        new_carry: uint1,
+        src1: seq<uint256>,
+        src2: seq<uint256>,
+        old_carry: uint1,
+        index: nat)
+    requires |dst| == |src1| == |src2|;
+    requires index < |src1|;
+    requires subb_inv(dst, old_carry, src1, src2, index);
+    requires (dst[index], new_carry)
+        == uint256_subb(src1[index], src2[index], old_carry);
+    ensures subb_inv(dst, new_carry, src1, src2, index + 1);
+    {
+        var (zs, bin) := seq_subb(src1[..index], src2[..index]);
+        var (z, bout) := uint256_subb(src1[index], src2[index], old_carry);
+
+        assert dst[..index+1] == zs + [z];
+        assert src1[..index+1] == src1[..index] + [src1[index]];
+        assert src2[..index+1] == src2[..index] + [src2[index]];
+    }
+
+    lemma subb_inv_post_lemma(
+        dst: seq<uint256>,
+        carry: uint1,
+        src1: seq<uint256>,
+        src2: seq<uint256>)
+        
+    requires |dst| == |src1| == |src2|;
+    requires subb_inv(dst, carry, src1, src2, |dst|);
+    ensures carry == 0 ==> to_nat(src1) - to_nat(src2) == to_nat(dst);
+    ensures carry == 1 ==> to_nat(src1) < to_nat(src2);
+    {
+        var index := |dst|;
+        assert dst[..index] == dst;
+        assert src1[..index] == src1;
+        assert src2[..index] == src2;
+    
+        seq_subb_nat_lemma(src1, src2, dst, carry);
+
+        assert to_nat(src1) - to_nat(src2) + carry * pow_B256(index) == to_nat(dst);
+
+        to_nat_bound_lemma(dst);
+    }
+
     predicate modexp_var_inv(
         a: nat,
         sig: nat,
@@ -27,9 +86,9 @@ module modexp_var_lemmas {
         sig: seq<uint256>,
         key: pub_key)
 
-        requires montmul_inv(a_slice, rr, NUM_WORDS, sig, key);
-        requires to_nat(rr) == key.RR;
-        ensures modexp_var_inv(to_nat(a_slice), to_nat(sig), 0, key);
+    requires montmul_inv(a_slice, rr, NUM_WORDS, sig, key);
+    requires to_nat(rr) == key.RR;
+    ensures modexp_var_inv(to_nat(a_slice), to_nat(sig), 0, key);
     {
         var m := key.m;
         var a := to_nat(a_slice);
@@ -142,6 +201,48 @@ module modexp_var_lemmas {
             cong(next_a, power(s, power(2, key.e') + 1), m);
             cong(next_a, power(s, key.e), m);
             cong(to_nat(next_a_slice), power(to_nat(sig), key.e), m);
+        }
+
+    }
+
+    function mod(a: int, n: nat): int
+        requires n != 0;
+    {
+        a % n
+    }
+
+    lemma modexp_var_correct_lemma(
+        raw_val: nat,
+        adjusted_val: nat,
+        carry: bool,
+        sig: nat,
+        key: pub_key)
+
+    requires pub_key_inv(key);
+    requires raw_val < sig + key.m;
+    requires cong(raw_val, power(sig, key.e), key.m);
+    requires carry ==> raw_val < key.m;
+    requires !carry ==> raw_val - key.m == adjusted_val;
+
+    ensures carry ==> raw_val == power(sig, key.e) % key.m;
+    ensures !carry ==> adjusted_val == power(sig, key.e) % key.m;
+    {
+        if carry {
+            cong_remainder_lemma(raw_val, power(sig, key.e), key.m);
+            assert raw_val == power(sig, key.e) % key.m;
+        } else {
+            assume sig < key.m; // TODO: fix this
+            calc ==> {
+                true;
+                    { cong_add_lemma_3(raw_val, -(key.m as int), key.m); }
+                cong(raw_val, adjusted_val, key.m);
+                    {
+                        cong_trans_lemma(adjusted_val, raw_val, power(sig, key.e), key.m);
+                    }
+                cong(adjusted_val, power(sig, key.e), key.m);
+            }
+
+            cong_remainder_lemma(adjusted_val, power(sig, key.e), key.m);
         }
     }
 }

--- a/otbn_model/code/mont_loop.vad
+++ b/otbn_model/code/mont_loop.vad
@@ -86,6 +86,7 @@ procedure mont_loop_0(
         x6 == old(x6);
         x7 == old(x7);
         x8 == 5;
+        x9 == old(x9);
         x10 == 4;
         x11 == old(x11);
         x12 == 30;
@@ -95,6 +96,7 @@ procedure mont_loop_0(
         x20 == old(x20);
         x21 == old(x21);
         x22 == x16;
+        x29 == old(x29);
         x30 == old(x30);
         x31 == old(x31);
 
@@ -237,6 +239,7 @@ procedure mont_loop_1(
         x6 == old(x6);
         x7 == old(x7);
         x8 == 4 + j + 1;
+        x9 == old(x9);
         x10 == 3 + j + 1;
         x11 == old(x11);
         x12 == 30;
@@ -245,6 +248,7 @@ procedure mont_loop_1(
         x20 == old(x20);
         x21 == old(x21);
         x22 == old(x22);
+        x29 == old(x29);
         x30 == old(x30);
         x31 == old(x31);
 
@@ -352,10 +356,12 @@ procedure mont_loop(
     ensures
         x6 == old(x6);
         x7 == old(x7);
+        x9 == old(x9);
         x11 == old(x11);
         x17 == old(x17);
         x20 == old(x20);
         x21 == old(x21);
+        x29 == old(x29);
         x30 == old(x30);
         x31 == old(x31);
 
@@ -405,6 +411,7 @@ procedure mont_loop(
             x6 == old(x6);
             x7 == old(x7);
             x8 == 4 + j;
+            x9 == old(x9);
             x10 == 3 + j;
             x11 == old(x11);
             x12 == 30;
@@ -412,6 +419,7 @@ procedure mont_loop(
             x17 == old(x17);
             x20 == old(x20);
             x21 == old(x21);
+            x29 == old(x29);
             x30 == NUM_WORDS;
             x31 == NUM_WORDS - 1;
 

--- a/otbn_model/code/mont_loop.vad
+++ b/otbn_model/code/mont_loop.vad
@@ -93,6 +93,7 @@ procedure mont_loop_0(
         x16 == old(x16);
         x17 == old(x17);
         x20 == old(x20);
+        x21 == old(x21);
         x22 == x16;
         x30 == old(x30);
         x31 == old(x31);
@@ -110,6 +111,7 @@ procedure mont_loop_0(
         p_1.full == a_slice[0] + y_iter.buff[0] * x_i;
 
         wmem == old(wmem);
+        xmem == old(xmem);
 {
    /* save pointer to modulus */
     addi(x22, x16, 0);
@@ -241,6 +243,7 @@ procedure mont_loop_1(
         x13 == 24;
         x17 == old(x17);
         x20 == old(x20);
+        x21 == old(x21);
         x22 == old(x22);
         x30 == old(x30);
         x31 == old(x31);
@@ -265,6 +268,7 @@ procedure mont_loop_1(
             next_y_iter.buff, next_m_iter.buff, initial_a_slice, next_a_slice, j+1);
 
         wmem == old(wmem);
+        xmem == old(xmem);
 {
     ghost var j := y_iter.index;
     /* load limb of y (operand a) and mult. with x_i: [w26, w27] <- y[j]*x_i */
@@ -351,6 +355,7 @@ procedure mont_loop(
         x11 == old(x11);
         x17 == old(x17);
         x20 == old(x20);
+        x21 == old(x21);
         x30 == old(x30);
         x31 == old(x31);
 
@@ -362,6 +367,7 @@ procedure mont_loop(
         montmul_inv(next_a_slice, x_iter.buff, x_iter.index, vars.y_iter.buff, vars.key);
 
         wmem == old(wmem);
+        xmem == old(xmem);
 {
     ghost var a_slice := initial_a_slice;
     ghost var p_1: uint512_view_t;
@@ -405,6 +411,7 @@ procedure mont_loop(
             x13 == 24;
             x17 == old(x17);
             x20 == old(x20);
+            x21 == old(x21);
             x30 == NUM_WORDS;
             x31 == NUM_WORDS - 1;
 
@@ -434,7 +441,8 @@ procedure mont_loop(
             initial_a_slice[j..] == a_slice[j..];
 
             wmem == old(wmem);
-            
+            xmem == old(xmem);
+
             mont_loop_inv(x_i, u_i, p_1, p_2,
                 y_iter.buff, m_iter.buff, initial_a_slice, a_slice, j);
             

--- a/otbn_model/code/montmul.vad
+++ b/otbn_model/code/montmul.vad
@@ -55,6 +55,7 @@ procedure montmul_0(ghost vars: mm_vars)
     ensures
         x11 == 2;
         x20 == old(x20);
+        x21 == old(x21);
         x30 == old(x30);
         x31 == old(x31);
 
@@ -62,6 +63,7 @@ procedure montmul_0(ghost vars: mm_vars)
         w31 == 0;
 
         wmem == old(wmem);
+        xmem == old(xmem);
 
         valid_wdr_view(wdrs, a_slice, 4, NUM_WORDS);
         to_nat(a_slice) == 0;
@@ -77,6 +79,8 @@ procedure montmul_0(ghost vars: mm_vars)
             x10 + loop_ctr == 4 + NUM_WORDS;
             x11 == 2;
             x20 == old(x20);
+            x21 == old(x21);
+
             x30 == NUM_WORDS;
             x31 == old(x31);
 
@@ -89,6 +93,7 @@ procedure montmul_0(ghost vars: mm_vars)
             a_slice[..x10 - 4] == seq_zero(x10 - 4);
 
             wmem == old(wmem);
+            xmem == old(xmem);
 
         decreases loop_ctr;
     {
@@ -118,6 +123,13 @@ procedure montmul(ghost vars: mm_vars)
         w31 == 0;
     
     ensures
+        x8 == 4;
+        x10 == 4;
+        x21 == old(x21);
+
+        xmem == old(xmem);
+        wmem == old(wmem);
+
         valid_wdr_view(wdrs, a_slice, 4, NUM_WORDS);
 
         montmul_inv(a_slice, vars.x_iter.buff, NUM_WORDS, vars.y_iter.buff, vars.key);
@@ -133,6 +145,7 @@ procedure montmul(ghost vars: mm_vars)
     while (Loop(x30))
         invariant
             x11 == 2;
+            x21 == old(x21);
             x30 == NUM_WORDS;
             x31 == NUM_WORDS - 1;
 
@@ -151,6 +164,7 @@ procedure montmul(ghost vars: mm_vars)
             valid_wdr_view(wdrs, a_slice, 4, NUM_WORDS);
 
             wmem == old(wmem);
+            xmem == old(xmem);
 
         decreases loop_ctr;
     {

--- a/otbn_model/code/montmul.vad
+++ b/otbn_model/code/montmul.vad
@@ -53,9 +53,11 @@ procedure montmul_0(ghost vars: mm_vars)
         mm_vars_inv(vars, wmem, x20, x19, x16, NA, x17);
 
     ensures
+        x9 == old(x9);
         x11 == 2;
         x20 == old(x20);
         x21 == old(x21);
+        x29 == old(x29);
         x30 == old(x30);
         x31 == old(x31);
 
@@ -76,11 +78,12 @@ procedure montmul_0(ghost vars: mm_vars)
 
     while (Loop(x30))
         invariant
+            x9 == old(x9);
             x10 + loop_ctr == 4 + NUM_WORDS;
             x11 == 2;
             x20 == old(x20);
             x21 == old(x21);
-
+            x29 == old(x29);
             x30 == NUM_WORDS;
             x31 == old(x31);
 
@@ -95,7 +98,8 @@ procedure montmul_0(ghost vars: mm_vars)
             wmem == old(wmem);
             xmem == old(xmem);
 
-        decreases loop_ctr;
+        decreases
+            loop_ctr;
     {
         let index := x10 - 4;
         a_slice := a_slice[index := 0];
@@ -124,13 +128,21 @@ procedure montmul(ghost vars: mm_vars)
     
     ensures
         x8 == 4;
+        x9 == old(x9);
         x10 == 4;
+        x11 == 2;
         x21 == old(x21);
+        x29 == old(x29);
+        x30 == NUM_WORDS;
+        x31 == NUM_WORDS - 1;
+
+        w31 == 0;
 
         xmem == old(xmem);
         wmem == old(wmem);
 
         valid_wdr_view(wdrs, a_slice, 4, NUM_WORDS);
+        mm_vars_inv(vars, wmem, NA, x19, x16, NA, x17);
 
         montmul_inv(a_slice, vars.x_iter.buff, NUM_WORDS, vars.y_iter.buff, vars.key);
 {
@@ -144,8 +156,10 @@ procedure montmul(ghost vars: mm_vars)
 
     while (Loop(x30))
         invariant
+            x9 == old(x9);
             x11 == 2;
             x21 == old(x21);
+            x29 == old(x29);
             x30 == NUM_WORDS;
             x31 == NUM_WORDS - 1;
 
@@ -177,6 +191,7 @@ procedure montmul(ghost vars: mm_vars)
         addi(x16, x6, 0);
         addi(x19, x7, 0);
     }
+
     /* restore pointers */
     li(x8, 4);
     li(x10, 4);

--- a/otbn_model/code/montmul.vad
+++ b/otbn_model/code/montmul.vad
@@ -118,7 +118,9 @@ procedure montmul(ghost vars: mm_vars)
         w31 == 0;
     
     ensures
-       montmul_inv(a_slice, vars.x_iter.buff, NUM_WORDS, vars.y_iter.buff, vars.key);
+        valid_wdr_view(wdrs, a_slice, 4, NUM_WORDS);
+
+        montmul_inv(a_slice, vars.x_iter.buff, NUM_WORDS, vars.y_iter.buff, vars.key);
 {
     a_slice := montmul_0(vars);
 

--- a/otbn_model/code/montmul_lemmas.dfy
+++ b/otbn_model/code/montmul_lemmas.dfy
@@ -1,4 +1,3 @@
-include "../spec/rsa_ops.dfy"
 include "mont_loop_lemmas.dfy"
 
 module montmul_lemmas {
@@ -29,5 +28,49 @@ module montmul_lemmas {
         }
         reveal cong();
         assert montmul_inv(a, x, i, y, key);
+    }
+
+    lemma r_r_inv_cancel_lemma(a: nat, key: pub_key)
+        requires pub_key_inv(key);
+        ensures cong(a * key.R_INV * key.R, a, key.m);
+    {
+        assert cong(key.R_INV * key.R, 1, key.m);
+        cong_mul_lemma_1(key.R_INV * key.R, 1, a, key.m);
+    }
+    
+    lemma r_r_inv_cancel_lemma_2(a: nat, b : nat, key: pub_key)
+        requires pub_key_inv(key);
+        requires cong(a, b * key.R_INV * key.R, key.m);
+        ensures cong(a, b, key.m);
+    {
+        assert cong(b * key.R_INV * key.R, b, key.m) by {
+            r_r_inv_cancel_lemma(b, key);
+        }
+        reveal cong();
+    }
+
+    lemma montmul_inv_lemma_1(a_slice: seq<uint256>,
+        x: seq<uint256>,
+        y: seq<uint256>,
+        key: pub_key)
+    
+        requires montmul_inv(a_slice, x, NUM_WORDS, y, key);
+        ensures cong(to_nat(a_slice), to_nat(x) * to_nat(y) * key.R_INV, key.m);
+    {
+        var m := key.m;
+        var a := to_nat(a_slice);
+        assert x[..NUM_WORDS] == x;
+
+        calc ==> {
+            cong(a * key.R, to_nat(x) * to_nat(y), m);
+                { cong_mul_lemma_1(a * key.R, to_nat(x) * to_nat(y), key.R_INV, m); }
+            cong(a * key.R * key.R_INV, to_nat(x) * to_nat(y) * key.R_INV, m);
+                { reveal cong(); }
+            cong(to_nat(x) * to_nat(y) * key.R_INV, a * key.R * key.R_INV, m);
+                { r_r_inv_cancel_lemma_2(to_nat(x) * to_nat(y) * key.R_INV, a, key); }
+            cong(to_nat(x) * to_nat(y) * key.R_INV, a, m);
+                { reveal cong(); }
+            cong(a, to_nat(x) * to_nat(y) * key.R_INV, m);
+        }
     }
 }

--- a/otbn_model/code/montmul_lemmas.dfy
+++ b/otbn_model/code/montmul_lemmas.dfy
@@ -10,19 +10,6 @@ module montmul_lemmas {
     import opened congruences
     import opened mont_loop_lemmas
 
-    function seq_zero(len: nat): (zs: seq<uint256>)
-        ensures |zs| == len
-    {
-        if len == 0 then []
-        else seq_zero(len - 1) + [0]
-    }
-
-    lemma seq_zero_to_nat_lemma(len: nat)
-        ensures to_nat(seq_zero(len)) == 0
-    {
-        reveal to_nat();
-    }
-
     lemma montmul_inv_lemma_0(
         a: seq<uint256>,
         x: seq<uint256>, 

--- a/otbn_model/spec/bv_ops.dfy
+++ b/otbn_model/spec/bv_ops.dfy
@@ -18,6 +18,8 @@ module bv_ops {
     type uint256 = i :int | 0 <= i < BASE_256
 	type uint512 = i :int | 0 <= i < BASE_512
 
+	type int12	 = i :int | -2048 <= i <= 2047
+
     datatype shift_t = SFT(left: bool, bytes: uint5)
 
 	const SFT_DFT :shift_t := SFT(true, 0);

--- a/otbn_model/spec/rsa_ops.dfy
+++ b/otbn_model/spec/rsa_ops.dfy
@@ -254,6 +254,23 @@ module rsa_ops {
         && |iter.buff| == 1
     }
 
+    predicate mm_vars_safe(
+        vars: mm_vars,
+        wmem: wmem_t,
+        x_addr: int,
+        y_addr: int,
+        m_addr: int,
+        rr_addr: int,
+        m0d_addr: int)
+    {
+        && mm_iter_inv(vars.x_iter, wmem, x_addr)
+        && mm_iter_inv(vars.y_iter, wmem, y_addr)
+
+        && mm_iter_inv(vars.m_iter, wmem, m_addr)
+        && mm_iter_inv(vars.rr_iter, wmem, rr_addr)
+        && m0d_iter_inv(vars.m0d_iter, wmem, m0d_addr)
+    }
+
     predicate mm_vars_inv(
         vars: mm_vars,
         wmem: wmem_t,
@@ -264,17 +281,9 @@ module rsa_ops {
         m0d_addr: int)
     {
         && pub_key_inv(vars.key)
-
-        && mm_iter_inv(vars.x_iter, wmem, x_addr)
-        && mm_iter_inv(vars.y_iter, wmem, y_addr)
-
-        && mm_iter_inv(vars.m_iter, wmem, m_addr)
+        && mm_vars_safe(vars, wmem, x_addr, y_addr, m_addr, rr_addr,m0d_addr)
         && to_nat(vars.m_iter.buff) == vars.key.m
-
-        && mm_iter_inv(vars.rr_iter, wmem, rr_addr)
         && to_nat(vars.rr_iter.buff) == vars.key.RR
-
-        && m0d_iter_inv(vars.m0d_iter, wmem, m0d_addr)
         && vars.m0d_iter.buff[0] == vars.key.m0d
     }
 }

--- a/otbn_model/spec/rsa_ops.dfy
+++ b/otbn_model/spec/rsa_ops.dfy
@@ -242,9 +242,10 @@ module rsa_ops {
 
     predicate mm_iter_inv(iter: iter_t, wmem: wmem_t, address: int)
     {
-        && iter_inv(iter, wmem, address)
-        && iter.index == 0
-        && |iter.buff| == NUM_WORDS
+        || address == NA
+        || (&& iter_inv(iter, wmem, address)
+            && iter.index == 0
+            && |iter.buff| == NUM_WORDS)
     }
 
     predicate m0d_iter_inv(iter: iter_t, wmem: wmem_t, address: int)
@@ -282,9 +283,9 @@ module rsa_ops {
         rr_addr: int,
         m0d_addr: int)
     {
-        && mm_vars_safe(vars, wmem, x_addr, y_addr, m_addr, rr_addr,m0d_addr)
+        && mm_vars_safe(vars, wmem, x_addr, y_addr, m_addr, rr_addr, m0d_addr)
         && to_nat(vars.m_iter.buff) == vars.key.m
-        && to_nat(vars.rr_iter.buff) == vars.key.RR
+        && (rr_addr == NA ||to_nat(vars.rr_iter.buff) == vars.key.RR)
         && vars.m0d_iter.buff[0] == vars.key.m0d
     }
 }

--- a/otbn_model/spec/rsa_ops.dfy
+++ b/otbn_model/spec/rsa_ops.dfy
@@ -48,6 +48,19 @@ module rsa_ops {
         to_nat_lemma_2([num.lh, num.uh]);
     }
 
+    function seq_zero(len: nat): (zs: seq<uint256>)
+        ensures |zs| == len
+    {
+        if len == 0 then []
+        else seq_zero(len - 1) + [0]
+    }
+
+    lemma seq_zero_to_nat_lemma(len: nat)
+        ensures to_nat(seq_zero(len)) == 0
+    {
+        reveal to_nat();
+    }
+
     lemma to_nat_bound_lemma(x: seq<uint256>)
         ensures to_nat(x) < pow_B256(|x|)
     {

--- a/otbn_model/spec/rsa_ops.dfy
+++ b/otbn_model/spec/rsa_ops.dfy
@@ -208,7 +208,8 @@ module rsa_ops {
 /* rsa/mm definions & lemmas */
 
    datatype pub_key = pub_key(
-        e: nat, 
+        e': nat, // e == 2 ** (e' + 1)
+        e: nat,
         m: nat,
         m0d: uint256,
         B256_INV: nat,
@@ -218,6 +219,8 @@ module rsa_ops {
 
     predicate pub_key_inv(key: pub_key)
     {
+        && key.e == power(2, key.e') + 1
+
         && key.m != 0
         && cong_B256(key.m0d * key.m, BASE_256-1)
 
@@ -242,7 +245,7 @@ module rsa_ops {
 
     predicate mm_iter_inv(iter: iter_t, wmem: wmem_t, address: int)
     {
-        || address == NA
+        || address == NA // TODO: make iter provide its own address in this case
         || (&& iter_inv(iter, wmem, address)
             && iter.index == 0
             && |iter.buff| == NUM_WORDS)

--- a/otbn_model/spec/rsa_ops.dfy
+++ b/otbn_model/spec/rsa_ops.dfy
@@ -211,6 +211,7 @@ module rsa_ops {
         e': nat, // e == 2 ** (e' + 1)
         e: nat,
         m: nat,
+        sig: nat,
         m0d: uint256,
         B256_INV: nat,
         R: nat,
@@ -225,6 +226,8 @@ module rsa_ops {
         && cong_B256(key.m0d * key.m, BASE_256-1)
 
         && cong(BASE_256 * key.B256_INV, 1, key.m)
+
+        && key.sig < key.m
 
         && key.R == power(BASE_256, NUM_WORDS)
 

--- a/otbn_model/spec/rsa_ops.dfy
+++ b/otbn_model/spec/rsa_ops.dfy
@@ -263,6 +263,8 @@ module rsa_ops {
         rr_addr: int,
         m0d_addr: int)
     {
+        && pub_key_inv(vars.key)
+
         && mm_iter_inv(vars.x_iter, wmem, x_addr)
         && mm_iter_inv(vars.y_iter, wmem, y_addr)
 
@@ -280,7 +282,6 @@ module rsa_ops {
         rr_addr: int,
         m0d_addr: int)
     {
-        && pub_key_inv(vars.key)
         && mm_vars_safe(vars, wmem, x_addr, y_addr, m_addr, rr_addr,m0d_addr)
         && to_nat(vars.m_iter.buff) == vars.key.m
         && to_nat(vars.rr_iter.buff) == vars.key.RR

--- a/otbn_model/spec/vt_ops.dfy
+++ b/otbn_model/spec/vt_ops.dfy
@@ -113,7 +113,7 @@ module vt_ops {
     }
 
     function bn_sid_next_iter(iter: iter_t, value: uint256, inc: bool): iter_t
-        requires exists addr: int, wmem: wmem_t :: iter_safe(iter, wmem, addr);
+        requires iter.index < |iter.buff|
     {
         iter.(index := if inc then iter.index + 1 else iter.index)
             .(buff := iter.buff[iter.index := value])

--- a/otbn_model/spec/vt_ops.dfy
+++ b/otbn_model/spec/vt_ops.dfy
@@ -123,15 +123,14 @@ module vt_ops {
     predicate iter_inv(iter: iter_t, wmem: wmem_t, address: int)
     {
         var base_addr := iter.base_addr;
+        // address is correct
+        && iter_mapped(iter, address)
         // base_addr points to a valid buffer
         && valid_wmem_base_addr(wmem, base_addr, |iter.buff|)
         // the view is consistent with wmem
         && wmem[base_addr] == iter.buff
-
         // the index is within bound (or at end)
         && iter.index <= |iter.buff|
-        // address is correct
-        && iter_mapped(iter, address)
     }
 
     predicate iter_safe(iter: iter_t, wmem: wmem_t, address: int)

--- a/otbn_model/spec/vt_ops.dfy
+++ b/otbn_model/spec/vt_ops.dfy
@@ -112,6 +112,13 @@ module vt_ops {
         iter.(index := if inc then iter.index + 1 else iter.index)
     }
 
+    function bn_sid_next_iter(iter: iter_t, value: uint256, inc: bool): iter_t
+        requires exists addr: int, wmem: wmem_t :: iter_safe(iter, wmem, addr);
+    {
+        iter.(index := if inc then iter.index + 1 else iter.index)
+            .(buff := iter.buff[iter.index := value])
+    }
+
     predicate iter_mapped(iter: iter_t, address: int)
     {   
         // we choose to ingore

--- a/otbn_model/spec/vt_ops.dfy
+++ b/otbn_model/spec/vt_ops.dfy
@@ -15,7 +15,8 @@ module vt_ops {
 
     datatype reg32_t = GPR(index: reg_index)
 
-    type gprs_t = gprs : seq<uint32> | |gprs| == 32 witness *
+    type gprs_t = gprs : seq<uint32>
+        | |gprs| == 32 witness *
 
     datatype reg256_t =
         | WDR(index: reg_index)
@@ -28,7 +29,35 @@ module vt_ops {
         r.WDR?
     }
 
-    type wdrs_t = wdrs : seq<uint256> | |wdrs| == 32 witness *
+    type wdrs_t = wdrs : seq<uint256>
+        | |wdrs| == 32 witness *
+
+/* wdr_view definion (SHADOW) */
+
+    datatype uint512_raw = uint512_cons(
+        lh: uint256, uh: uint256, full: uint512)
+
+	type uint512_view_t = num: uint512_raw |
+		&& num.lh == uint512_lh(num.full)
+		&& num.uh == uint512_uh(num.full)
+		witness *
+
+    predicate valid_uint512_view(
+        wdrs: wdrs_t, num: uint512_view_t,
+        li: int, ui: int)
+        requires -1 <= li < BASE_5;
+        requires -1 <= ui < BASE_5;
+    {
+        && (li == NA || wdrs[li] == num.lh)
+        && (ui == NA || wdrs[ui] == num.uh)
+    }
+
+    predicate valid_wdr_view(wdrs: wdrs_t, slice: seq<uint256>, start: nat, len: nat)
+    {   
+        && |slice| == len
+        && start + len <= 32
+        && wdrs[start..start+len] == slice
+    }
 
 /* flags definions */
 
@@ -57,11 +86,59 @@ module vt_ops {
 
 /* memory definions */
 
+    type xmem_t = map<int, uint32>
+
+    predicate valid_xmem_addr(xmem: xmem_t, addr:int)
+    {
+        && addr in xmem
+    }
+
     type wmem_t = map<int, seq<uint256>>
 
-    predicate valid_xmem_addr(h: map<int, uint32>, addr:int)
+    predicate valid_wmem_base_addr(wmem: wmem_t, addr: int, size: nat)
     {
-        addr in h
+        && addr in wmem
+        && |wmem[addr]| == size != 0
+        // buff does not extend beyond mem limit
+        && addr + 32 * size <= DMEM_LIMIT
+    }
+
+/* iter_t definion (SHADOW) */
+
+    datatype iter_t = iter_cons(base_addr: int, index: nat, buff: seq<uint256>)
+
+    function bn_lid_next_iter(iter: iter_t, inc: bool): iter_t
+    {
+        iter.(index := if inc then iter.index + 1 else iter.index)
+    }
+
+    predicate iter_mapped(iter: iter_t, address: int)
+    {   
+        // we choose to ingore
+        || (address == NA)
+        // address is correct
+        || (address == iter.base_addr + 32 * iter.index)
+    }
+
+    predicate iter_inv(iter: iter_t, wmem: wmem_t, address: int)
+    {
+        var base_addr := iter.base_addr;
+        // base_addr points to a valid buffer
+        && valid_wmem_base_addr(wmem, base_addr, |iter.buff|)
+        // the view is consistent with wmem
+        && wmem[base_addr] == iter.buff
+
+        // the index is within bound (or at end)
+        && iter.index <= |iter.buff|
+        // address is correct
+        && iter_mapped(iter, address)
+    }
+
+    predicate iter_safe(iter: iter_t, wmem: wmem_t, address: int)
+    {
+        && iter_inv(iter, wmem, address)
+        // stronger constraint so we can dereference
+        && iter.index < |iter.buff|
     }
 
 /* state definions */
@@ -76,14 +153,15 @@ module vt_ops {
 
         fgroups: fgroups_t,
 
-        xmem: map<int, uint32>,
+        xmem: xmem_t,
         wmem: wmem_t,
 
         ok: bool)
     {
         function eval_reg32(r: reg32_t) : uint32
         {
-            gprs[r.index]
+            if r.index == 0 then 0
+            else gprs[r.index]
         }
 
         function eval_reg256(r: reg256_t) : uint256
@@ -328,67 +406,6 @@ module vt_ops {
             case While(cond, body) => eval_while(body, eval_cond(s, cond), s, r)
     }
 
-/* auxiliary definions */
 
-    datatype uint512_raw = uint512_cons(
-        lh: uint256, uh: uint256, full: uint512)
 
-	type uint512_view_t = num: uint512_raw |
-		&& num.lh == uint512_lh(num.full)
-		&& num.uh == uint512_uh(num.full)
-		witness *
-
-    predicate valid_uint512_view(
-        wdrs: wdrs_t, num: uint512_view_t,
-        li: int, ui: int)
-        requires -1 <= li < BASE_5;
-        requires -1 <= ui < BASE_5;
-    {
-        && (li == NA || wdrs[li] == num.lh)
-        && (ui == NA || wdrs[ui] == num.uh)
-    }
-
-    predicate valid_wdr_view(wdrs: wdrs_t, slice: seq<uint256>, start: nat, len: nat)
-    {   
-        && |slice| == len
-        && start + len <= 32
-        && wdrs[start..start+len] == slice
-    }
-
-    datatype iter_t = iter_cons(base_addr: int, index: nat, buff: seq<uint256>)
-
-    function bn_lid_next_iter(iter: iter_t, inc: bool): iter_t
-    {
-        iter.(index := if inc then iter.index + 1 else iter.index)
-    }
-
-    predicate iter_mapped(iter: iter_t, address: int)
-    {   
-        // we choose to ingore
-        || (address == NA)
-        // address is correct
-        || (address == iter.base_addr + 32 * iter.index)
-    }
-
-    predicate iter_inv(iter: iter_t, wmem: wmem_t, address: int)
-    {
-        var base_addr := iter.base_addr;
-        // base_addr points to a valid buffer
-        && base_addr in wmem
-        // the view is consistent with wmem
-        && wmem[base_addr] == iter.buff
-        // buff does not extend beyond mem limit
-        && base_addr + 32 * |iter.buff| <= DMEM_LIMIT
-        // the index is within bound (or at end)
-        && iter.index <= |iter.buff| != 0
-        // address is correct
-        && iter_mapped(iter, address)
-    }
-
-    predicate iter_safe(iter: iter_t, wmem: wmem_t, address: int)
-    {
-        && iter_inv(iter, wmem, address)
-        // stronger constraint so we can dereference
-        && iter.index < |iter.buff|
-    }
 }


### PR DESCRIPTION
the out most procedure `modexp_var` ensures that the output buff contains the right value (view is consistent with the main memory & is the modexp result). 

this version is pretty rough around the edges, TODOs:
* fill in multiplications procedures stubs (256x256 for example)
* handle mm constants procedures (if they are pre-computed just remove them)
* fill in some missing congruence proofs in calcs 
* refactor how `mm_vars` and `pub_key` are structured, some predicates are redundant