### PR TITLE
otbn update to better match top level procs in opentitan

### DIFF
--- a/arch/otbn/printer.s.dfy
+++ b/arch/otbn/printer.s.dfy
@@ -324,6 +324,7 @@ method getFunctions(c: code, defs: set<string>, res: seq<(string, codes)>)
 class Printer {
     var labelCount: nat;
     var depth: int;
+    var printed: set<string>;
 
     constructor()
     {
@@ -366,7 +367,6 @@ class Printer {
             {
                 printIndent(); printIfCond(icond); print(", label_"); print(labelCount); print("\n");
                 printCode(tbody);
-                print(goto )
                 printIndent(); print("label_"); print(labelCount); print(":\n");
                 var fsize := codeSize(fbody);
                 if fsize != 0 {
@@ -386,28 +386,37 @@ class Printer {
             case Comment(com) => print(com);
     }
 
-    method printProc(code: code)
+    method printTopLevelProc(name: string, code: code)
         requires code.Function?
         modifies this
     {
-        print(".globl modexp_var"); print("\n");
-        var defs, res := getFunctions(code, {}, []); 
+        print(".globl "); print(name); print("\n");
+        var defs, res := getFunctions(code, {}, []);
         var i := 0;
         while i < |res|
         {
-            print(res[i].0); print(":\n");
-            printCode(Block(res[i].1));
+            var func_name := res[i].0;
+            if func_name !in printed {
+                printed := printed + {func_name};
+                print(func_name); print(":\n");
+                printCode(Block(res[i].1));
+                printIndent(); print("ret\n\n");
+            }
             i := i + 1;
-            printIndent(); print("ret\n\n");
         }
     }
 }
 
 method Main()
 {
-    reveal va_code_modexp_var();
+    reveal va_code_modexp_var_3072_f4();
+    reveal va_code_modexp_var_3072_3();
+
     var p := new Printer();
-    p.printProc(va_code_modexp_var());
+    p.printTopLevelProc("modexp_var_3072_f4",
+        va_code_modexp_var_3072_f4());
+    p.printTopLevelProc("modexp_var_3072_3",
+        va_code_modexp_var_3072_3());
 }
 
 }

--- a/arch/otbn/simulator.i.dfy
+++ b/arch/otbn/simulator.i.dfy
@@ -326,10 +326,10 @@ method ExecuteDemo()
         0x638 := 0x8fc62fbe,
         0x63c := 0x114e6da5];
 
-    state := state.(mem := mem);
-    state := state.eval_code(va_code_modexp_var());
+    // state := state.(mem := mem);
+    // state := state.eval_code(va_code_modexp_var());
 
-    dump_mem(state, 0x000008c0, 96);
+    // dump_mem(state, 0x000008c0, 96);
 }
 
 method Main()

--- a/gen/rsa_verify_3072.s
+++ b/gen/rsa_verify_3072.s
@@ -1,0 +1,215 @@
+/*
+  generated through vale/dafny in veri-titan project
+  commit hash: 338507a9b57c23bbec14eebd21d8c13fa86911b8
+*/
+
+.globl modexp_var_3072_f4
+modexp_var_3072_f4:
+  bn.xor w31, w31, w31 << 0, FG0
+  li x8, 4
+  li x9, 3
+  li x10, 4
+  li x11, 2
+  addi x19, x23, 0
+  addi x20, x26, 0
+  addi x21, x24, 0
+  jal x1, montmul
+  loopi 12, 3
+    bn.sid x8, 0(x21++)
+    addi x8, x8, 1
+    nop
+  loopi 16, 9
+    addi x19, x24, 0
+    addi x20, x24, 0
+    addi x21, x24, 0
+    jal x1, montmul
+    loopi 12, 3
+      bn.sid x8, 0(x21++)
+      addi x8, x8, 1
+      nop
+    nop
+  addi x19, x23, 0
+  addi x20, x24, 0
+  addi x21, x24, 0
+  jal x1, montmul
+  bn.add w31, w31, w31 << 0, FG0
+  li x17, 16
+  loopi 12, 5
+    bn.movr x11, x8++
+    bn.lid x9, 0(x16++)
+    bn.subb w2, w2, w3 << 0, FG0
+    bn.movr x17++, x11
+    nop
+  csrrs x2, 1984, x0
+  andi x2, x2, 1
+  li x8, 4
+  bne x2, x0, label_0
+  li x8, 16
+  label_0:
+  addi x21, x24, 0
+  loopi 12, 3
+    bn.sid x8, 0(x21++)
+    addi x8, x8, 1
+    nop
+  ret
+
+montmul:
+  bn.lid x9, 0(x17)
+  bn.mov w2, w31
+  loopi 12, 2
+    bn.movr x10++, x11
+    nop
+  loopi 12, 7
+    bn.lid x11, 0(x20++)
+    addi x6, x16, 0
+    addi x7, x19, 0
+    jal x1, mont_loop
+    addi x16, x6, 0
+    addi x19, x7, 0
+    nop
+  li x8, 4
+  li x10, 4
+  ret
+
+mont_loop:
+  addi x22, x16, 0
+  li x12, 30
+  li x13, 24
+  li x8, 4
+  li x10, 4
+  bn.lid x12, 0(x19++)
+  jal x1, mul256_w30xw2
+  bn.movr x13, x8++
+  bn.add w30, w27, w24 << 0, FG0
+  bn.addc w29, w26, w31 << 0, FG0
+  bn.mov w25, w3
+  jal x1, mul256_w30xw25
+  bn.mov w25, w27
+  bn.mov w24, w30
+  bn.lid x12, 0(x16++)
+  jal x1, mul256_w30xw25
+  bn.add w27, w27, w24 << 0, FG0
+  bn.addc w28, w26, w31 << 0, FG0
+  loopi 11, 15
+    bn.lid x12, 0(x19++)
+    bn.movr x13, x8++
+    jal x1, mul256_w30xw2
+    bn.add w27, w27, w24 << 0, FG0
+    bn.addc w26, w26, w31 << 0, FG0
+    bn.add w24, w27, w29 << 0, FG0
+    bn.addc w29, w26, w31 << 0, FG0
+    bn.lid x12, 0(x16++)
+    jal x1, mul256_w30xw25
+    bn.add w27, w27, w24 << 0, FG0
+    bn.addc w26, w26, w31 << 0, FG0
+    bn.add w24, w27, w28 << 0, FG0
+    bn.addc w28, w26, w31 << 0, FG0
+    bn.movr x10++, x13
+    nop
+  bn.add w24, w29, w28 << 0, FG1
+  bn.movr x10++, x13
+  bn.add w31, w31, w31 << 0, FG0
+  csrrs x2, 1985, x0
+  andi x2, x2, 1
+  beq x2, x0, label_1
+  li x12, 30
+  li x13, 24
+  addi x16, x22, 0
+  li x8, 4
+  loopi 12, 5
+    bn.lid x13, 0(x16++)
+    bn.movr x12, x8
+    bn.subb w24, w30, w24 << 0, FG0
+    bn.movr x8++, x13
+    nop
+  label_1:
+  li x8, 4
+  li x10, 4
+  ret
+
+mul256_w30xw2:
+  bn.mulqacc.z w30.0, w2.0, 0
+  bn.mulqacc w30.1, w2.0, 64
+  bn.mulqacc.so w27.L, w30.0, w2.1, 64, FG0
+  bn.mulqacc w30.2, w2.0, 0
+  bn.mulqacc w30.1, w2.1, 0
+  bn.mulqacc w30.0, w2.2, 0
+  bn.mulqacc w30.3, w2.0, 64
+  bn.mulqacc w30.2, w2.1, 64
+  bn.mulqacc w30.1, w2.2, 64
+  bn.mulqacc.so w27.U, w30.0, w2.3, 64, FG0
+  bn.mulqacc w30.3, w2.1, 0
+  bn.mulqacc w30.2, w2.2, 0
+  bn.mulqacc w30.1, w2.3, 0
+  bn.mulqacc w30.3, w2.2, 64
+  bn.mulqacc.so w26.L, w30.2, w2.3, 64, FG0
+  bn.mulqacc.so w26.U, w30.3, w2.3, 0, FG0
+  ret
+
+mul256_w30xw25:
+  bn.mulqacc.z w30.0, w25.0, 0
+  bn.mulqacc w30.1, w25.0, 64
+  bn.mulqacc.so w27.L, w30.0, w25.1, 64, FG0
+  bn.mulqacc w30.2, w25.0, 0
+  bn.mulqacc w30.1, w25.1, 0
+  bn.mulqacc w30.0, w25.2, 0
+  bn.mulqacc w30.3, w25.0, 64
+  bn.mulqacc w30.2, w25.1, 64
+  bn.mulqacc w30.1, w25.2, 64
+  bn.mulqacc.so w27.U, w30.0, w25.3, 64, FG0
+  bn.mulqacc w30.3, w25.1, 0
+  bn.mulqacc w30.2, w25.2, 0
+  bn.mulqacc w30.1, w25.3, 0
+  bn.mulqacc w30.3, w25.2, 64
+  bn.mulqacc.so w26.L, w30.2, w25.3, 64, FG0
+  bn.mulqacc.so w26.U, w30.3, w25.3, 0, FG0
+  ret
+
+.globl modexp_var_3072_3
+modexp_var_3072_3:
+  bn.xor w31, w31, w31 << 0, FG0
+  li x8, 4
+  li x9, 3
+  li x10, 4
+  li x11, 2
+  addi x19, x23, 0
+  addi x20, x26, 0
+  addi x21, x24, 0
+  jal x1, montmul
+  loopi 12, 3
+    bn.sid x8, 0(x21++)
+    addi x8, x8, 1
+    nop
+  addi x19, x24, 0
+  addi x20, x24, 0
+  addi x21, x24, 0
+  jal x1, montmul
+  loopi 12, 3
+    bn.sid x8, 0(x21++)
+    addi x8, x8, 1
+    nop
+  addi x19, x23, 0
+  addi x20, x24, 0
+  addi x21, x24, 0
+  jal x1, montmul
+  bn.add w31, w31, w31 << 0, FG0
+  li x17, 16
+  loopi 12, 5
+    bn.movr x11, x8++
+    bn.lid x9, 0(x16++)
+    bn.subb w2, w2, w3 << 0, FG0
+    bn.movr x17++, x11
+    nop
+  csrrs x2, 1984, x0
+  andi x2, x2, 1
+  li x8, 4
+  bne x2, x0, label_2
+  li x8, 16
+  label_2:
+  addi x21, x24, 0
+  loopi 12, 3
+    bn.sid x8, 0(x21++)
+    addi x8, x8, 1
+    nop
+  ret
+

--- a/impl/otbn/modexp_var.i.vad
+++ b/impl/otbn/modexp_var.i.vad
@@ -184,6 +184,7 @@ procedure modexp_var_0(ghost init_vars: mvars)
         mvars_iter_init(out_iter, heap, x24, NA);
         mvars_inv(vars, heap, x24, x24, x16, x17, old(x26), x23);
         modexp_var_inv(to_nat(out_iter.buff), 0, vars.rsa);
+        mvars_init(init_vars, heap, old(x16), old(x17), old(x26), x23, x24);
 {
     xor_clear_lemma(w31);
 
@@ -210,9 +211,6 @@ procedure modexp_var_0(ghost init_vars: mvars)
 
     vars := vars.(x_it := out_iter).(y_it := out_iter);
     modexp_var_inv_pre_lemma(a_view, rr_iter.buff, sig_iter.buff, vars.rsa);
-
-    assume x23 == old(x23);
-    assume x24 == old(x24);
 }
 
 procedure sub_mod(
@@ -331,18 +329,19 @@ procedure modexp_var_3072_f4(
         x23 == sig_ptr;
         x24 == out_ptr;
 
-        mvars_init(init_vars, heap, m_ptr, m0d_ptr, rr_ptr, sig_ptr, out_ptr);
+        mvars_init(init_vars, heap,
+            m_ptr, m0d_ptr, rr_ptr, sig_ptr, out_ptr);
 
         init_vars.rsa.E0 == 16;
 
-//     ensures
-//         mvars_init(init_vars, heap,
-//             m_ptr, m0d_ptr, rr_ptr, sig_ptr, out_ptr);
-//         // out_iter contains a valid view of memory
-//         iter_inv(out_iter, heap, out_ptr);
-//         // out_iter contains the right value
-//         let rsa := init_vars.rsa in 
-//         to_nat(out_iter.buff) == mod(Pow(rsa.SIG, rsa.E), rsa.M);
+    ensures
+        mvars_init(init_vars, heap,
+            m_ptr, m0d_ptr, rr_ptr, sig_ptr, out_ptr);
+        // out_iter contains a valid view of memory
+        iter_inv(out_iter, heap, out_ptr);
+        // out_iter contains the right value
+        let rsa := init_vars.rsa in 
+        to_nat(out_iter.buff) == mod(Pow(rsa.SIG, rsa.E), rsa.M);
 {
     ghost var vars := init_vars;
     vars, out_iter := modexp_var_0(init_vars);
@@ -366,7 +365,8 @@ procedure modexp_var_3072_f4(
             mvars_iter_init(out_iter, heap, x24, NA);
             modexp_var_inv(to_nat(out_iter.buff), i, vars.rsa);
             mvars_inv(vars, heap, x24, x24, x16, x17, rr_ptr, sig_ptr);
-            // mvars_init(init_vars, heap, m_ptr, m0d_ptr, rr_ptr, sig_ptr, out_ptr); // might not need this
+            mvars_init(init_vars, heap,
+                m_ptr, m0d_ptr, rr_ptr, sig_ptr, out_ptr);
 
             out_ptr != x16;
             out_ptr != x17;
@@ -390,9 +390,6 @@ procedure modexp_var_3072_f4(
         modexp_var_inv_peri_lemma(prev_a_view, a_view, i, vars.rsa);
     
         i := i + 1;
-
-        assume x23 == sig_ptr;
-        assume x24 == out_ptr;
     }
 
     addi(x19, x23, 0);

--- a/impl/otbn/modexp_var.i.vad
+++ b/impl/otbn/modexp_var.i.vad
@@ -409,9 +409,90 @@ procedure modexp_var_3072_f4(
     let carry := fgroups.fg0.cf;
     modexp_var_correct_lemma(to_nat(raw_view), to_nat(adjusted_view), carry, vars.rsa);
 
+    read_fg0();
     li(x8, 4);
 
+    if (x2 == x0) {
+        li(x8, 16);
+    }
+
+    addi(x21, x24, 0);
+
+    out_iter := iter_cons(x21, 0, heap[x21].b);
+    out_iter := write_to_dmem(out_iter);
+}
+
+
+procedure modexp_var_3072_3(
+    ghost init_vars: mvars,
+    ghost m_ptr: uint32,
+    ghost m0d_ptr: uint32,
+    ghost rr_ptr: uint32,
+    ghost sig_ptr: uint32,
+    ghost out_ptr: uint32)
+
+    returns (ghost out_iter: iter_t)
+
+    {:noInline}
+    {:frame false}
+
+    requires
+        x16 == m_ptr;
+        x17 == m0d_ptr;
+        x26 == rr_ptr;
+        x23 == sig_ptr;
+        x24 == out_ptr;
+
+        mvars_init(init_vars, heap,
+            m_ptr, m0d_ptr, rr_ptr, sig_ptr, out_ptr);
+
+        init_vars.rsa.E0 == 1;
+
+    ensures
+        mvars_init(init_vars, heap,
+            m_ptr, m0d_ptr, rr_ptr, sig_ptr, out_ptr);
+        // out_iter contains a valid view of memory
+        iter_inv(out_iter, heap, out_ptr);
+        // out_iter contains the right value
+        let rsa := init_vars.rsa in 
+        to_nat(out_iter.buff) == mod(Pow(rsa.SIG, rsa.E), rsa.M);
+{
+    ghost var vars := init_vars;
+    vars, out_iter := modexp_var_0(init_vars);
+
+    addi(x19, x24, 0);
+    addi(x20, x24, 0);
+    addi(x21, x24, 0);
+
+    ghost var prev_a_view := out_iter.buff;
+    ghost var a_view := prev_a_view;
+    a_view := montmul(vars);
+
+    out_iter := write_to_dmem(out_iter);
+    
+    vars := vars.(x_it := out_iter).(y_it := out_iter);
+
+    modexp_var_inv_peri_lemma(prev_a_view, a_view, 0, vars.rsa);
+
+    addi(x19, x23, 0);
+    addi(x20, x24, 0);
+    addi(x21, x24, 0);
+
+    prev_a_view := out_iter.buff;
+
+    vars := vars.(x_it := out_iter).(y_it := vars.sig_it);
+    a_view := montmul(vars);
+
+    modexp_var_inv_post_lemma(prev_a_view, a_view, vars.sig_it.buff, vars.rsa);
+
+    ghost var raw_view := wdrs[4..4+NUM_WORDS];
+    let adjusted_view := sub_mod(raw_view, vars.m_it);
+    
+    let carry := fgroups.fg0.cf;
+    modexp_var_correct_lemma(to_nat(raw_view), to_nat(adjusted_view), carry, vars.rsa);
+
     read_fg0();
+    li(x8, 4);
 
     if (x2 == x0) {
         li(x8, 16);

--- a/impl/otbn/modexp_var.i.vad
+++ b/impl/otbn/modexp_var.i.vad
@@ -76,6 +76,73 @@ ghost procedure modexp_var_correct_lemma(
 
 function mod(a: int, n: int): int extern;
 
+procedure write_to_dmem(ghost iter: iter_t)
+    returns (ghost next_iter: iter_t)
+
+    requires
+        (x8 == 4) || (x8 == 16);
+
+        iter_safe(iter, heap, x21);
+        seq_len(iter.buff) == NUM_WORDS;
+        iter.index == 0;
+    
+    modifies
+        x8; x21; mem; heap;
+
+    reads
+        wdrs;
+
+    ensures
+        iter_inv(next_iter, heap, iter.base_ptr);
+        next_iter.base_ptr == iter.base_ptr;
+        seq_len(next_iter.buff) == NUM_WORDS;
+        next_iter.buff == wdrs[old(x8)..old(x8)+NUM_WORDS];
+        heap == old(heap)[next_iter.base_ptr := WBUFF(next_iter.buff)];
+{
+    ghost var start := x8;
+    next_iter := iter;
+
+    while (LoopImm(12))
+        invariant
+            x8 == start + next_iter.index;
+
+            iter_inv(next_iter, heap, x21);
+            next_iter.index + loop_ctr == NUM_WORDS;
+            seq_len(next_iter.buff) == NUM_WORDS;
+
+            next_iter.buff[..next_iter.index] == wdrs[start..start+next_iter.index];
+            wdrs == old(wdrs);
+
+            next_iter.base_ptr == iter.base_ptr;
+            heap == old(heap)[next_iter.base_ptr := WBUFF(next_iter.buff)];
+
+        decreases
+            loop_ctr;
+    {   
+        ghost var index := next_iter.index;
+        ghost var last_iter := next_iter;
+
+        next_iter := bn_sid_safe(x8, false, 0, x21, true, next_iter);
+        addi(x8, x8, 1);
+
+        ghost var item := next_iter.buff[index];
+        assert next_iter.buff[index] == wdrs[start+index];
+
+        calc == {
+            next_iter.buff[..next_iter.index];
+            ==
+            seq_append(last_iter.buff[..index], item);
+            ==
+            seq_append(wdrs[start..start+index], item);
+            ==
+            wdrs[start..start+index+1];
+            ==
+            wdrs[start..start+next_iter.index];
+        }
+    }
+    next_iter := next_iter.(index := 0);
+}
+
 function mvars_init(
     vars: mvars,
     heap: heap_t,
@@ -85,56 +152,67 @@ function mvars_init(
     sig_ptr: uint32,
     out_ptr: uint32) : bool extern;
 
-procedure modexp_var_0(
-    ghost init_vars: mvars,
-    ghost m_ptr: uint32,
-    ghost m0d_ptr: uint32,
-    ghost rr_ptr: uint32,
-    ghost sig_ptr: uint32,
-    ghost out_ptr: uint32)
+procedure modexp_var_0(ghost init_vars: mvars)
+    returns (ghost vars: mvars,
+        ghost out_iter: iter_t)
+
+    {:frame false}
 
     requires
-        mvars_init(init_vars, heap,
-            m_ptr, m0d_ptr, rr_ptr, sig_ptr, out_ptr);
-
-    reads
-        x0;
-        mem; heap;
-
-    modifies
-        fgroups;
-        x8; x9; x10; x11; x16; x17; x18; x29; x30; x31;
-        w31;
+        mvars_init(init_vars, heap, 
+            x16 /* m_ptr */,
+            x17 /* m0d_ptr */,
+            x26 /* rr_ptr */,
+            x23 /* sig_ptr */,
+            x24 /* out_ptr */);
 
     ensures
-        x8 == 4;
         x9 == 3;
         x10 == 4;
         x11 == 2;
-        x29 == init_vars.rsa.E0;
-        x30 == NUM_WORDS;
-        x31 == NUM_WORDS - 1;
+
+        x23 == old(x23);
+        x24 == old(x24);
 
         w31 == 0;
 
-        mvars_inv(init_vars, heap, NA, NA, x16, x17, x18, NA);
+        x24 != x16;
+        x24 != x17;
+
+        vars.rsa == init_vars.rsa;
+        vars.sig_it == init_vars.sig_it;
+        mvars_iter_init(out_iter, heap, x24, NA);
+        mvars_inv(vars, heap, x24, x24, x16, x17, old(x26), x23);
+        modexp_var_inv(to_nat(out_iter.buff), 0, vars.rsa);
 {
     xor_clear_lemma(w31);
+
     bn_xor(w31, w31, w31, SFT_DFT, 0);
-
-    lw(x30, 4, x0);
-
-    addi(x31, x30, (-1));
-
-    lw(x16, 16, x0);
-    lw(x17, 8, x0);
-    lw(x18, 12, x0);
-    lw(x29, 0, x0);
 
     li(x8, 4);
     li(x9, 3);
     li(x10, 4);
     li(x11, 2);
+
+    addi(x19, x23, 0);
+    addi(x20, x26, 0);
+    addi(x21, x24, 0);
+
+    let sig_iter := init_vars.sig_it;
+    let rr_iter := init_vars.rr_it;
+
+    vars := init_vars.(x_it := rr_iter).(y_it := sig_iter);
+
+    let a_view := montmul(vars);
+
+    out_iter := iter_cons(x21, 0, heap[x21].b);
+    out_iter := write_to_dmem(out_iter);
+
+    vars := vars.(x_it := out_iter).(y_it := out_iter);
+    modexp_var_inv_pre_lemma(a_view, rr_iter.buff, sig_iter.buff, vars.rsa);
+
+    assume x23 == old(x23);
+    assume x24 == old(x24);
 }
 
 procedure sub_mod(
@@ -220,73 +298,6 @@ procedure sub_mod(
     subb_inv_post_lemma(adjusted_view, new_carry, raw_view, m_it.buff);
 }
 
-procedure write_to_dmem(ghost iter: iter_t)
-    returns (ghost next_iter: iter_t)
-
-    requires
-        (x8 == 4) || (x8 == 16);
-
-        iter_safe(iter, heap, x21);
-        seq_len(iter.buff) == NUM_WORDS;
-        iter.index == 0;
-    
-    modifies
-        x8; x21; mem; heap;
-
-    reads
-        wdrs;
-
-    ensures
-        iter_inv(next_iter, heap, iter.base_ptr);
-        next_iter.base_ptr == iter.base_ptr;
-        seq_len(next_iter.buff) == NUM_WORDS;
-        next_iter.buff == wdrs[old(x8)..old(x8)+NUM_WORDS];
-        heap == old(heap)[next_iter.base_ptr := WBUFF(next_iter.buff)];
-{
-    ghost var start := x8;
-    next_iter := iter;
-
-    while (LoopImm(12))
-        invariant
-            x8 == start + next_iter.index;
-
-            iter_inv(next_iter, heap, x21);
-            next_iter.index + loop_ctr == NUM_WORDS;
-            seq_len(next_iter.buff) == NUM_WORDS;
-
-            next_iter.buff[..next_iter.index] == wdrs[start..start+next_iter.index];
-            wdrs == old(wdrs);
-
-            next_iter.base_ptr == iter.base_ptr;
-            heap == old(heap)[next_iter.base_ptr := WBUFF(next_iter.buff)];
-
-        decreases
-            loop_ctr;
-    {   
-        ghost var index := next_iter.index;
-        ghost var last_iter := next_iter;
-
-        next_iter := bn_sid_safe(x8, false, 0, x21, true, next_iter);
-        addi(x8, x8, 1);
-
-        ghost var item := next_iter.buff[index];
-        assert next_iter.buff[index] == wdrs[start+index];
-
-        calc == {
-            next_iter.buff[..next_iter.index];
-            ==
-            seq_append(last_iter.buff[..index], item);
-            ==
-            seq_append(wdrs[start..start+index], item);
-            ==
-            wdrs[start..start+index+1];
-            ==
-            wdrs[start..start+next_iter.index];
-        }
-    }
-    next_iter := next_iter.(index := 0);
-}
-
 procedure read_fg0()
     reads
         x0; fgroups;
@@ -300,7 +311,7 @@ procedure read_fg0()
     read_carry_flag_lemma(fgroups.fg0);
 }
 
-procedure modexp_var(
+procedure modexp_var_3072_f4(
     ghost init_vars: mvars,
     ghost m_ptr: uint32,
     ghost m0d_ptr: uint32,
@@ -314,72 +325,63 @@ procedure modexp_var(
     {:frame false}
 
     requires
-        mvars_init(init_vars, heap,
-            m_ptr, m0d_ptr, rr_ptr, sig_ptr, out_ptr);
+        x16 == m_ptr;
+        x17 == m0d_ptr;
+        x26 == rr_ptr;
+        x23 == sig_ptr;
+        x24 == out_ptr;
 
-    ensures
-        mvars_init(init_vars, heap,
-            m_ptr, m0d_ptr, rr_ptr, sig_ptr, out_ptr);
-        // out_iter contains a valid view of memory
-        iter_inv(out_iter, heap, out_ptr);
-        // out_iter contains the right value
-        let rsa := init_vars.rsa in 
-        to_nat(out_iter.buff) == mod(Pow(rsa.SIG, rsa.E), rsa.M);
+        mvars_init(init_vars, heap, m_ptr, m0d_ptr, rr_ptr, sig_ptr, out_ptr);
+
+        init_vars.rsa.E0 == 16;
+
+//     ensures
+//         mvars_init(init_vars, heap,
+//             m_ptr, m0d_ptr, rr_ptr, sig_ptr, out_ptr);
+//         // out_iter contains a valid view of memory
+//         iter_inv(out_iter, heap, out_ptr);
+//         // out_iter contains the right value
+//         let rsa := init_vars.rsa in 
+//         to_nat(out_iter.buff) == mod(Pow(rsa.SIG, rsa.E), rsa.M);
 {
-    ghost var a_view: seq(uint256);
-    modexp_var_0(init_vars, m_ptr, m0d_ptr, rr_ptr, sig_ptr, out_ptr);
+    ghost var vars := init_vars;
+    vars, out_iter := modexp_var_0(init_vars);
 
-    lw(x19, 20, x0);
-    addi(x20, x18, 0);
-    lw(x21, 28, x0);
-
-    let sig_iter := init_vars.sig_it;
-    let rr_iter := init_vars.rr_it;
-
-    ghost var vars := init_vars.(x_it := rr_iter).(y_it := sig_iter);
-    a_view := montmul(vars);
-
-    out_iter := iter_cons(out_ptr, 0, heap[out_ptr].b);
-    out_iter := write_to_dmem(out_iter);
-
-    vars := vars.(x_it := out_iter).(y_it := out_iter);
-
-    modexp_var_inv_pre_lemma(a_view, rr_iter.buff, sig_iter.buff, vars.rsa);
-    
     ghost var i : nat := 0;
 
-    while (Loop(x29))
+    while (LoopImm(16))
         invariant
             x9 == 3;
             x10 == 4;
             x11 == 2;
 
+            x23 == sig_ptr;
+            x24 == out_ptr;
+    
             w31 == 0;
 
-            init_vars.rsa == vars.rsa;
-            init_vars.sig_it== vars.sig_it;
+            vars.rsa == init_vars.rsa;
+            vars.sig_it == init_vars.sig_it;
 
-            mvars_iter_init(out_iter, heap, out_ptr, NA);
-            out_iter.buff == a_view;
-
-            mvars_inv(vars, heap, out_ptr, out_ptr, x16, x17, rr_ptr, sig_ptr);
-            modexp_var_inv(to_nat(a_view), i, vars.rsa);
-            mvars_init(init_vars, heap, m_ptr, m0d_ptr, rr_ptr, sig_ptr, out_ptr);
+            mvars_iter_init(out_iter, heap, x24, NA);
+            modexp_var_inv(to_nat(out_iter.buff), i, vars.rsa);
+            mvars_inv(vars, heap, x24, x24, x16, x17, rr_ptr, sig_ptr);
+            // mvars_init(init_vars, heap, m_ptr, m0d_ptr, rr_ptr, sig_ptr, out_ptr); // might not need this
 
             out_ptr != x16;
             out_ptr != x17;
 
-            i + loop_ctr == vars.rsa.E0; 
+            i + loop_ctr == 16;
 
         decreases
             loop_ctr;
     {
-        lw(x20, 28, x0);
-        lw(x19, 28, x0);
-        lw(x21, 28, x0);
+        addi(x19, x24, 0);
+        addi(x20, x24, 0);
+        addi(x21, x24, 0);
 
-        let prev_a_view := a_view;
-        a_view := montmul(vars);
+        let prev_a_view := out_iter.buff;
+        let a_view := montmul(vars);
 
         out_iter := write_to_dmem(out_iter);
         
@@ -388,17 +390,21 @@ procedure modexp_var(
         modexp_var_inv_peri_lemma(prev_a_view, a_view, i, vars.rsa);
     
         i := i + 1;
+
+        assume x23 == sig_ptr;
+        assume x24 == out_ptr;
     }
 
-    lw(x19, 20, x0);
-    lw(x20, 28, x0);
-    lw(x21, 28, x0);
-    let prev_a_view := a_view;
+    addi(x19, x23, 0);
+    addi(x20, x24, 0);
+    addi(x21, x24, 0);
 
-    vars := vars.(x_it := out_iter).(y_it := sig_iter);
-    a_view := montmul(vars);
+    let prev_a_view := out_iter.buff;
 
-    modexp_var_inv_post_lemma(prev_a_view, a_view, sig_iter.buff, vars.rsa);
+    vars := vars.(x_it := out_iter).(y_it := vars.sig_it);
+    let a_view := montmul(vars);
+
+    modexp_var_inv_post_lemma(prev_a_view, a_view, vars.sig_it.buff, vars.rsa);
 
     ghost var raw_view := wdrs[4..4+NUM_WORDS];
     let adjusted_view := sub_mod(raw_view, vars.m_it);
@@ -406,7 +412,6 @@ procedure modexp_var(
     let carry := fgroups.fg0.cf;
     modexp_var_correct_lemma(to_nat(raw_view), to_nat(adjusted_view), carry, vars.rsa);
 
-    lw(x21, 28, x0);
     li(x8, 4);
 
     read_fg0();
@@ -414,6 +419,8 @@ procedure modexp_var(
     if (x2 == x0) {
         li(x8, 16);
     }
+
+    addi(x21, x24, 0);
 
     out_iter := iter_cons(x21, 0, heap[x21].b);
     out_iter := write_to_dmem(out_iter);

--- a/impl/otbn/mont_loop.i.vad
+++ b/impl/otbn/mont_loop.i.vad
@@ -170,9 +170,9 @@ procedure mont_loop_0(
         // x16 == old(x16);
         // x17 == old(x17);
         // x20 == old(x20);
-        // x21 == old(x21);
+        // x23 == old(x23);
         x22 == x16;
-        // x29 == old(x29);
+        // x24 == old(x24);
         // x30 == old(x30);
 
         w2 == xi;
@@ -293,7 +293,8 @@ procedure mont_loop_1(
         x20 == old(x20);
         x21 == old(x21);
         x22 == old(x22);
-        x29 == old(x29);
+        x23 == old(x23);
+        x24 == old(x24);
         x30 == old(x30);
 
         w2 == xi;
@@ -395,7 +396,8 @@ procedure mont_loop(
         x17 == old(x17);
         x20 == old(x20);
         x21 == old(x21);
-        x29 == old(x29);
+        x23 == old(x23);
+        x24 == old(x24);
 
         w3 == old(w3);
         w31 == old(w31);
@@ -447,7 +449,8 @@ procedure mont_loop(
             x17 == old(x17);
             x20 == old(x20);
             x21 == old(x21);
-            x29 == old(x29);
+            x23 == old(x23);
+            x24 == old(x24);
 
             w2 == xi;
             w3 == old(w3);

--- a/impl/otbn/montmul.i.vad
+++ b/impl/otbn/montmul.i.vad
@@ -119,6 +119,8 @@ procedure montmul(ghost vars: mvars)
         x10 == 4;
         x11 == 2;
         x21 == old(x21);
+        x23 == old(x23);
+        x24 == old(x24);
         x29 == old(x29);
 
         w31 == 0;
@@ -177,6 +179,9 @@ procedure montmul(ghost vars: mvars)
     /* restore pointers */
     li(x8, 4);
     li(x10, 4);
+
+    assume x23 == old(x23);
+    assume x24 == old(x24);
 }
 
 

--- a/impl/otbn/montmul.i.vad
+++ b/impl/otbn/montmul.i.vad
@@ -51,7 +51,8 @@ procedure montmul_0(ghost vars: mvars)
         x11 == 2;
         x20 == old(x20);
         x21 == old(x21);
-        x29 == old(x29);
+        x23 == old(x23);
+        x24 == old(x24);
 
         w3 == vars.rsa.M0D;
         w31 == 0;
@@ -75,7 +76,8 @@ procedure montmul_0(ghost vars: mvars)
             x11 == 2;
             x20 == old(x20);
             x21 == old(x21);
-            x29 == old(x29);
+            x23 == old(x23);
+            x24 == old(x24);
 
             w2 == 0;
             w3 == vars.rsa.M0D;
@@ -118,10 +120,10 @@ procedure montmul(ghost vars: mvars)
         x9 == old(x9);
         x10 == 4;
         x11 == 2;
+
         x21 == old(x21);
         x23 == old(x23);
         x24 == old(x24);
-        x29 == old(x29);
 
         w31 == 0;
 
@@ -145,7 +147,8 @@ procedure montmul(ghost vars: mvars)
             x9 == old(x9);
             x11 == 2;
             x21 == old(x21);
-            x29 == old(x29);
+            x23 == old(x23);
+            x24 == old(x24);
 
             iter_inv(x_it, heap, x20);
             x_it.index + loop_ctr == NUM_WORDS;
@@ -179,9 +182,6 @@ procedure montmul(ghost vars: mvars)
     /* restore pointers */
     li(x8, 4);
     li(x10, 4);
-
-    assume x23 == old(x23);
-    assume x24 == old(x24);
 }
 
 

--- a/impl/otbn/run_modexp.s
+++ b/impl/otbn/run_modexp.s
@@ -15,13 +15,20 @@
  * w0). See comment at the end of the file for expected values.
  */
 main:
-  jal      x1, modexp_var
+  /* Set pointers to buffers. */
+  la        x24, out_buf
+  la        x16, in_mod
+  la        x23, in_buf
+  la        x26, rr
+  la        x17, m0inv
+
+  jal      x1, modexp_var_3072_f4
   /* pointer to out buffer */
-  lw        x21, 28(x0)
+  la        x21, out_buf
 
   /* copy all limbs of result to wide reg file */
   li       x8, 0
-  loop     x30, 2
+  loopi     12, 2
     bn.lid   x8, 0(x21++)
     addi     x8, x8, 1
 
@@ -29,131 +36,114 @@ main:
 
 .data
 
-/* exponent of the exponent (e') (Full exponent is e=2^e'+1) */
-.word 0x00000010
+/* Output buffer */
+.globl out_buf
+out_buf:
+  .zero 384
 
-/* number of limbs (N) */
-.word 0x0000000C
-
-/* pointer to m0' (dptr_m0d) */
-.word 0x00000280
-
-/* pointer to RR (dptr_rr) */
-.word 0x000002c0
-
-/* load pointer to modulus (dptr_m) */
-.word 0x00000080
-
-/* pointer to base bignum buffer (dptr_in) */
-.word 0x000004c0
-
-/* pointer to exponent buffer (dptr_exp, unused for encrypt) */
-.word 0x000006c0
-
-/* pointer to out buffer (dptr_out) */
-.word 0x000008c0
-
-/* Modulus */
-.org 0x80
-.word 0x6a6a75e1
-.word 0xa018ddc5
-.word 0x687bb168
-.word 0x8e8205a5
-.word 0x7dbfffa7
-.word 0xc8722ac5
-.word 0xf84d21cf
-.word 0xe1312531
-.word 0x0ce3f8a3
-.word 0xa825f988
-.word 0x57f51964
-.word 0xb27e206a
-.word 0x8e1dd008
-.word 0x1c4fb8d7
-.word 0x824fb142
-.word 0x1c8be7b3
-.word 0x7b9d6366
-.word 0xc56ad0f2
-.word 0xef762d5b
-.word 0x4b1431e3
-.word 0x8ae28eb9
-.word 0xd41db7aa
-.word 0x43cccdf7
-.word 0x91b74a84
-.word 0x80183850
-.word 0x30e74d0d
-.word 0xb62ed015
-.word 0x235574d2
-.word 0x8c28f251
-.word 0x4f40def2
-.word 0x24e2efdb
-.word 0x9ebd1ff2
-.word 0xfa7b49ee
-.word 0x2819a938
-.word 0x6e66b8c8
-.word 0x24e41546
-.word 0x4d783a7c
-.word 0xd2947d3d
-.word 0x1ab269e9
-.word 0xfad39f16
-.word 0xaab78f7b
-.word 0x49d8b510
-.word 0x35bf0dfb
-.word 0xeb274754
-.word 0x069eccc9
-.word 0xc13c437e
-.word 0xe3bc0f60
-.word 0xc9e0e12f
-.word 0xc253ac43
-.word 0x89c240e0
-.word 0xc4aba4e5
-.word 0xedf34bc0
-.word 0x5402c462
-.word 0x4021b0bd
-.word 0x996b6241
-.word 0xc3d9945f
-.word 0xa137ac60
-.word 0xf0250bf5
-.word 0xc8c7100f
-.word 0xb70d6b88
-.word 0x78916a8c
-.word 0x33370e5d
-.word 0x3970dcb9
-.word 0xaf4c58b4
-.word 0x5f78cb0d
-.word 0xb02d90b7
-.word 0xeb6c3d05
-.word 0x04afc71a
-.word 0x45185f0f
-.word 0x987caa5b
-.word 0x33976249
-.word 0x565afdbc
-.word 0x80a85056
-.word 0x59e07655
-.word 0x9a29e77d
-.word 0x7a8dfb7f
-.word 0x782e0204
-.word 0x4d6713ff
-.word 0x131000ea
-.word 0xe18e1206
-.word 0x21f57f30
-.word 0xf24f038b
-.word 0x59cf874d
-.word 0x24c50525
-.word 0xb52f170d
-.word 0x46c9adde
-.word 0x90e82c73
-.word 0x1344ceaf
-.word 0x663209f2
-.word 0x24bd4fbf
-.word 0x5e4ed04d
-.word 0x0fce770a
-.word 0x81f78793
-.word 0xa792e13e
-.word 0xa6c7bf58
-.word 0xe1df9be8
+/* Modulus of test key */
+.globl in_mod
+in_mod:
+  .word 0x6a6a75e1
+  .word 0xa018ddc5
+  .word 0x687bb168
+  .word 0x8e8205a5
+  .word 0x7dbfffa7
+  .word 0xc8722ac5
+  .word 0xf84d21cf
+  .word 0xe1312531
+  .word 0x0ce3f8a3
+  .word 0xa825f988
+  .word 0x57f51964
+  .word 0xb27e206a
+  .word 0x8e1dd008
+  .word 0x1c4fb8d7
+  .word 0x824fb142
+  .word 0x1c8be7b3
+  .word 0x7b9d6366
+  .word 0xc56ad0f2
+  .word 0xef762d5b
+  .word 0x4b1431e3
+  .word 0x8ae28eb9
+  .word 0xd41db7aa
+  .word 0x43cccdf7
+  .word 0x91b74a84
+  .word 0x80183850
+  .word 0x30e74d0d
+  .word 0xb62ed015
+  .word 0x235574d2
+  .word 0x8c28f251
+  .word 0x4f40def2
+  .word 0x24e2efdb
+  .word 0x9ebd1ff2
+  .word 0xfa7b49ee
+  .word 0x2819a938
+  .word 0x6e66b8c8
+  .word 0x24e41546
+  .word 0x4d783a7c
+  .word 0xd2947d3d
+  .word 0x1ab269e9
+  .word 0xfad39f16
+  .word 0xaab78f7b
+  .word 0x49d8b510
+  .word 0x35bf0dfb
+  .word 0xeb274754
+  .word 0x069eccc9
+  .word 0xc13c437e
+  .word 0xe3bc0f60
+  .word 0xc9e0e12f
+  .word 0xc253ac43
+  .word 0x89c240e0
+  .word 0xc4aba4e5
+  .word 0xedf34bc0
+  .word 0x5402c462
+  .word 0x4021b0bd
+  .word 0x996b6241
+  .word 0xc3d9945f
+  .word 0xa137ac60
+  .word 0xf0250bf5
+  .word 0xc8c7100f
+  .word 0xb70d6b88
+  .word 0x78916a8c
+  .word 0x33370e5d
+  .word 0x3970dcb9
+  .word 0xaf4c58b4
+  .word 0x5f78cb0d
+  .word 0xb02d90b7
+  .word 0xeb6c3d05
+  .word 0x04afc71a
+  .word 0x45185f0f
+  .word 0x987caa5b
+  .word 0x33976249
+  .word 0x565afdbc
+  .word 0x80a85056
+  .word 0x59e07655
+  .word 0x9a29e77d
+  .word 0x7a8dfb7f
+  .word 0x782e0204
+  .word 0x4d6713ff
+  .word 0x131000ea
+  .word 0xe18e1206
+  .word 0x21f57f30
+  .word 0xf24f038b
+  .word 0x59cf874d
+  .word 0x24c50525
+  .word 0xb52f170d
+  .word 0x46c9adde
+  .word 0x90e82c73
+  .word 0x1344ceaf
+  .word 0x663209f2
+  .word 0x24bd4fbf
+  .word 0x5e4ed04d
+  .word 0x0fce770a
+  .word 0x81f78793
+  .word 0xa792e13e
+  .word 0xa6c7bf58
+  .word 0xe1df9be8
 
 /* Montgomery constant m0' */
-.org 0x280
+.globl m0inv
+m0inv:
 .word 0xf09b71df
 .word 0xfd3e34f7
 .word 0x0b908e3b
@@ -172,7 +162,8 @@ main:
 .word 0x7da9803a
 
 /* Squared Mongomery Radix RR = (2^3072)^2 mod N */
-.org 0x2c0
+.globl rr
+rr:
 .word 0xa3eb77fa
 .word 0x9db9a2ac
 .word 0x2c19d4ae
@@ -271,7 +262,8 @@ main:
 .word 0x9e2dcea8
 
 /* signature */
-.org 0x4c0
+.globl in_buf
+in_buf:
 .word 0xceb7e983
 .word 0xe693b200
 .word 0xf9153989


### PR DESCRIPTION
some changes to the top most level procedures being printed
updates to the printer so the two version for different exponents can be printed
updates to the test code
add generated otbn assembly file 