### PR TITLE
Include Vale dependencies in README and build.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,15 +71,22 @@ We assume the following packages are installed by the user:
 
 `ninja` (1.10.+)
 
-[`dotnet`](https://dotnet.microsoft.com/download) 
+[`dotnet`](https://dotnet.microsoft.com/download)
 
 [`nuget`](https://www.nuget.org/downloads)
+
+[`python`](https://www.python.org/) >= 3.0
 
 We also assume some otbn tools are available:
 
 [`otbn-as`](https://github.com/lowRISC/opentitan/tree/master/hw/ip/otbn/util)
 
 [`otbn-ld`](https://github.com/lowRISC/opentitan/tree/master/hw/ip/otbn/util)
+
+Finally, you will need all the Vale dependencies listed
+[here](https://github.com/project-everest/vale/blob/otbn-custom/INSTALL.md#building-vale-from-source).
+This is because a custom version of Vale will be compiled from source during
+setup.
 
 To prepare for the build process, run: 
 ```

--- a/build.py
+++ b/build.py
@@ -123,6 +123,7 @@ def setup_tools():
     version = subprocess_run("ninja --version")
     if not version.startswith("1.10."):
         print("[WARN] ninja not found or unexpected version.  Expected 1.10.*, found: " + version)
+
     # dotnet
     version = subprocess_run("dotnet --list-sdks")
     if "5.0" not in version:
@@ -131,21 +132,45 @@ def setup_tools():
         print("[INFO] Found dotnet version: " + version)
 
     # nuget
-    version = subprocess_run("nuget help | grep Version")
+    version = subprocess_run("nuget help | grep -m 1 Version")
     if "5.5" not in version:
         print("[WARN] nuget not found or unexpected version.  Expected 5.5, found: " + version)
     else:
         print("[INFO] Found nuget version: " + version)
 
-    path = subprocess_run("which otbn-as")
+    # C# compiler (Vale)
+    path = subprocess_run("which dmsc")
+    if "dmsc" not in path:
+        # Check for mcs (mono C# compiler) instead
+        path = subprocess_run("which mcs")
+        if "mcs" not in path:
+            print("[WARN] C# compiler (dmsc or mcs - Vale dependency) not found")
+        else:
+            print("[INFO] mcs (Vale dependency) found")
+    else:
+        print("[INFO] dmsc (Vale dependency) found")
 
+    # scons (Vale)
+    path = subprocess_run("which scons")
+    if "scons" not in path:
+        print("[WARN] scons (Vale dependency) not found")
+    else:
+        print("[INFO] scons (Vale dependency) found")
+
+    # F# compiler (Vale)
+    path = subprocess_run("which fsharpc")
+    if "fsharpc" not in path:
+        print("[WARN] fsharpc (Vale dependency) not found")
+    else:
+        print("[INFO] fsharpc (Vale dependency) found")
+
+    path = subprocess_run("which otbn-as")
     if "otbn-as" not in path:
         print("[WARN] otbn-as not found")
     else:
         print("[INFO] otbn-as found")
 
     path = subprocess_run("which otbn-ld")
-
     if "otbn-ld" not in path:
         print("[WARN] otbn-ld not found")
     else:
@@ -200,7 +225,7 @@ def list_dfy_deps(dfy_file):
             continue
         if i == 0:
             # print(dfy_file)
-            continue 
+            continue
         else:
             include = get_ver_path(include)
             includes.append(include)


### PR DESCRIPTION
I recently got the repo set up, and had to do some figuring out to realize that I needed to install Vale's dependencies as well because `build.py setup` builds Vale from source. So this PR:
- Adds some additional dependency information to the README (adds Python and a link to Vale's install instructions for those dependencies -- could also list them, but that risks getting out of sync)
- Adds checks in `build.py` that check Vale dependencies (these could get out of sync, but it's just a warning -- they say "vale dependency" so if someone gets this they can check the up-to-date list and decide to just proceed if the dependency is no longer needed)

Also, includes a minor fix to the nuget version check; when I first ran `build.py` it just blocked on this `grep` because apparently `nuget help` didn't indicate to `grep` that the input from the pipe was done. I added `-m 1` to make `grep` stop on the first match.