### PR TITLE
Update names of OTBN build scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,9 +79,9 @@ We assume the following packages are installed by the user:
 
 We assume some otbn tools are available:
 
-[`otbn-as`](https://github.com/lowRISC/opentitan/tree/master/hw/ip/otbn/util)
+[`otbn_as.py`](https://github.com/lowRISC/opentitan/tree/master/hw/ip/otbn/util)
 
-[`otbn-ld`](https://github.com/lowRISC/opentitan/tree/master/hw/ip/otbn/util)
+[`otbn_ld.py`](https://github.com/lowRISC/opentitan/tree/master/hw/ip/otbn/util)
 
 We also assume the [`Singular`](https://www.singular.uni-kl.de/) tool is installed, which is used by the custom version of the Dafny language installed by our builds script.
 

--- a/build.py
+++ b/build.py
@@ -38,10 +38,10 @@ rule dll-run
     command = dotnet $in > $out
 
 rule otbn-as
-    command = otbn-as $in -o $out
+    command = otbn_as.py $in -o $out
 
 rule otbn-ld
-    command = otbn-ld $in -o $out
+    command = otbn_ld.py $in -o $out
 """
 
 OTBN_ASM_PATH = "gen/otbn_modexp.s"
@@ -161,17 +161,17 @@ def setup_tools():
     else:
         print("[INFO] fsharpc (Vale dependency) found")
 
-    path = subprocess_run("which otbn-as")
-    if "otbn-as" not in path:
-        print("[WARN] otbn-as not found")
+    path = subprocess_run("which otbn_as.py")
+    if "otbn_as.py" not in path:
+        print("[WARN] otbn_as.py not found")
     else:
-        print("[INFO] otbn-as found")
+        print("[INFO] otbn_as.py found")
 
-    path = subprocess_run("which otbn-ld")
-    if "otbn-ld" not in path:
-        print("[WARN] otbn-ld not found")
+    path = subprocess_run("which otbn_ld.py")
+    if "otbn_ld.py" not in path:
+        print("[WARN] otbn_ld.py not found")
     else:
-        print("[INFO] otbn-ld found")
+        print("[INFO] otbn_ld.py found")
 
     while 1:
         print("confirm dependecies are installed [y/n] ", end='')


### PR DESCRIPTION
As of https://github.com/lowRISC/opentitan/pull/12233, OpenTitan renamed the `otbn-as` and `otbn-ld` scripts to `otbn_as.py` and `otbn_ld.py`. This updates the veri-titan setup so that everything builds; I regenerated `build.ninja` and checked locally.

After this change, local OpenTitan checkouts will need to be updated in order to get the scripts with the new names.
