### PR TITLE
Add a counter to modexp for hardening

### DIFF
--- a/gen/otbn_modexp.s
+++ b/gen/otbn_modexp.s
@@ -37,6 +37,10 @@ modexp_var_3072_f4:
   li x10, 4
   li x11, 2
 
+  /* Initialize a counter to double-check that the loop completes (a
+      protection against fault injection). */
+  li x5, 0
+
   /* Convert input to Montgomery domain.
        [w15:w4] <= (dmem[x23]*dmem[x26]*R^-1) mod M = (A * R) mod M */
   addi x19, x23, 0
@@ -46,37 +50,27 @@ modexp_var_3072_f4:
 
   /* Store Montgomery-form input in dmem.
        dmem[x24] <= [w15:w4] = (A * R) mod M */
-  loopi 12, 2
+  loopi 12, 3
     bn.sid x8, 0(x21++)
     addi x8, x8, 1
-
-  /* Initialize a counter to double-check that the loop completes (a
-      protection against fault injection). */
-  li x5, 0
+    addi x5, x5, 1
 
   /* 16 consecutive Montgomery squares on the outbut buffer, i.e. after loop:
        dmem[out_buf] <= dmem[out_buf]^65536*R mod M */
-  loopi 16, 8
+  loopi 16, 9
 
     /* dmem[out_buf]  <= montmul(dmem[out_buf], dmem[out_buf]) */
     addi x19, x24, 0
     addi x20, x24, 0
     addi x21, x24, 0
     jal x1, montmul
-    loopi 12, 2
+    loopi 12, 3
       bn.sid x8, 0(x21++)
       addi x8, x8, 1
+      addi x5, x5, 1
 
     /* Update counter. */
     addi x5, x5, 1
-
-  /* If the counter value doesn't match expectations, cause a deliberate
-     error (WDR reference > 31) to end the program. */
-  li x2, 16
-  beq x2, x5, label_0
-  li x2, 255
-  bn.sid x0, 0(x2)
-  label_0:
 
   /* Final multiplication and conversion of result from Montgomery domain.
        out_buf  <= montmul(*x28, *x20) = montmul(dmem[in_buf], dmem[out_buf]) */
@@ -102,15 +96,24 @@ modexp_var_3072_f4:
   csrrs x2, 1984, x0
   andi x2, x2, 1
   li x8, 4
-  bne x2, x0, label_1
+  bne x2, x0, label_0
   li x8, 16
-  label_1:
+  label_0:
 
   /* Store result in dmem: dmem[out_buf] <= A^65537 mod M */
   addi x21, x24, 0
-  loopi 12, 2
+  loopi 12, 3
     bn.sid x8, 0(x21++)
     addi x8, x8, 1
+    addi x5, x5, 1
+
+  /* If the counter value doesn't match expectations, cause a deliberate
+     error (WDR reference > 31) to end the program. */
+  li x2, 232
+  beq x2, x5, label_1
+  li x2, 255
+  bn.sid x0, 0(x2)
+  label_1:
   ret
 
 .globl montmul

--- a/impl/otbn/modexp_var.i.vad
+++ b/impl/otbn/modexp_var.i.vad
@@ -155,6 +155,19 @@ procedure write_to_dmem(ghost iter: iter_t)
     next_iter := next_iter.(index := 0);
 }
 
+/* Causes a deliberate error in order to stop execution (e.g. if a possible
+   attack is detected). */
+procedure throw_error()
+
+    {:frame false}
+
+    requires false;
+{
+      li(x2, 255);
+      ghost var iter := b256_iter_cons(x21, 0, heap[x21].b256);
+      let next_iter := bn_sid_safe(x0, false, 0, x2, false, iter);
+}
+
 function mvars_init(
     vars: mvars,
     heap: heap_t,
@@ -490,9 +503,7 @@ procedure modexp_var_3072_f4(
     comment("   error (WDR reference > 31) to end the program. */");
     li(x2, 232);
     if (x2 != x5) {
-      li(x2, 255);
-      ghost var iter := b256_iter_cons(x21, 0, heap[x21].b256);
-      let next_iter := bn_sid_safe(x0, false, 0, x2, false, iter);
+      throw_error();
     }
 }
 

--- a/impl/otbn/modexp_var.i.vad
+++ b/impl/otbn/modexp_var.i.vad
@@ -349,7 +349,7 @@ procedure modexp_var_3072_f4(
         // out_iter contains a valid view of memory
         iter_inv(out_iter, heap, out_ptr);
         // out_iter contains the right value
-        let rsa := init_vars.rsa in 
+        let rsa := init_vars.rsa in
         to_nat(out_iter.buff) == mod(Pow(rsa.SIG, rsa.E), rsa.M);
 {
     comment("/**");
@@ -381,11 +381,16 @@ procedure modexp_var_3072_f4(
 
     ghost var i : nat := 0;
 
+    comment("/* Initialize a counter to double-check that the loop completes (a");
+    comment("    protection against fault injection). */");
+    li(x5, 0);
+
     comment("/* 16 consecutive Montgomery squares on the outbut buffer, i.e. after loop:");
     comment("     dmem[out_buf] <= dmem[out_buf]^65536*R mod M */");
 
     while (LoopImm(16))
         invariant
+            x5 == i;
             x9 == 3;
             x10 == 4;
             x11 == 2;
@@ -427,8 +432,18 @@ procedure modexp_var_3072_f4(
 
         modexp_var_inv_peri_lemma(prev_a_view, a_view, i, vars.rsa);
 
+        comment("/* Update counter. */");
+        addi(x5, x5, 1);
+
         i := i + 1;
-        nop();
+    }
+    comment("/* If the counter value doesn't match expectations, cause a deliberate");
+    comment("   error (WDR reference > 31) to end the program. */");
+    li(x2, 16);
+    if (x2 != x5) {
+      li(x2, 255);
+      ghost var iter := b256_iter_cons(x21, 0, heap[x21].b256);
+      let next_iter := bn_sid_safe(x0, false, 0, x2, false, iter);
     }
 
     comment("/* Final multiplication and conversion of result from Montgomery domain.");

--- a/impl/otbn/modexp_var.i.vad
+++ b/impl/otbn/modexp_var.i.vad
@@ -83,17 +83,21 @@ procedure write_to_dmem(ghost iter: iter_t)
     requires
         (x8 == 4) || (x8 == 16);
 
+        // Magic number below is 2^32 - 12
+        0 <= x5 < 4294967284;
+
         iter_safe(iter, heap, x21);
         seq_len(iter.buff) == NUM_WORDS;
         iter.index == 0;
     
     modifies
-        x8; x21; flat; heap;
+        x5; x8; x21; flat; heap;
 
     reads
         wdrs;
 
     ensures
+        x5 == old(x5) + 12;
         iter_inv(next_iter, heap, iter.base_ptr);
         next_iter.base_ptr == iter.base_ptr;
         seq_len(next_iter.buff) == NUM_WORDS;
@@ -102,9 +106,11 @@ procedure write_to_dmem(ghost iter: iter_t)
 {
     ghost var start := x8;
     next_iter := iter;
+    ghost var orig_counter := x5;
 
     while (LoopImm(12))
         invariant
+            x5 == orig_counter + (12 - loop_ctr);
             x8 == start + next_iter.index;
 
             iter_inv(next_iter, heap, x21);
@@ -143,6 +149,8 @@ procedure write_to_dmem(ghost iter: iter_t)
             ==
             wdrs[start..start+next_iter.index];
         }
+
+        addi(x5, x5, 1);
     }
     next_iter := next_iter.(index := 0);
 }
@@ -171,6 +179,7 @@ procedure modexp_var_0(ghost init_vars: mvars)
             x24 /* out_ptr */);
 
     ensures
+        x5 == 12;
         x9 == 3;
         x10 == 4;
         x11 == 2;
@@ -199,6 +208,10 @@ procedure modexp_var_0(ghost init_vars: mvars)
     li(x9, 3);
     li(x10, 4);
     li(x11, 2);
+
+    comment("/* Initialize a counter to double-check that the loop completes (a");
+    comment("    protection against fault injection). */");
+    li(x5, 0);
 
     comment("/* Convert input to Montgomery domain.");
     comment("     [w15:w4] <= (dmem[x23]*dmem[x26]*R^-1) mod M = (A * R) mod M */");
@@ -377,20 +390,17 @@ procedure modexp_var_3072_f4(
     comment(" */");
 
     ghost var vars := init_vars;
+
     vars, out_iter := modexp_var_0(init_vars);
 
     ghost var i : nat := 0;
-
-    comment("/* Initialize a counter to double-check that the loop completes (a");
-    comment("    protection against fault injection). */");
-    li(x5, 0);
 
     comment("/* 16 consecutive Montgomery squares on the outbut buffer, i.e. after loop:");
     comment("     dmem[out_buf] <= dmem[out_buf]^65536*R mod M */");
 
     while (LoopImm(16))
         invariant
-            x5 == i;
+            x5 == 12 + (13 * i);
             x9 == 3;
             x10 == 4;
             x11 == 2;
@@ -437,14 +447,6 @@ procedure modexp_var_3072_f4(
 
         i := i + 1;
     }
-    comment("/* If the counter value doesn't match expectations, cause a deliberate");
-    comment("   error (WDR reference > 31) to end the program. */");
-    li(x2, 16);
-    if (x2 != x5) {
-      li(x2, 255);
-      ghost var iter := b256_iter_cons(x21, 0, heap[x21].b256);
-      let next_iter := bn_sid_safe(x0, false, 0, x2, false, iter);
-    }
 
     comment("/* Final multiplication and conversion of result from Montgomery domain.");
     comment("     out_buf  <= montmul(*x28, *x20) = montmul(dmem[in_buf], dmem[out_buf]) */");
@@ -483,6 +485,15 @@ procedure modexp_var_3072_f4(
 
     out_iter := b256_iter_cons(x21, 0, heap[x21].b256);
     out_iter := write_to_dmem(out_iter);
+
+    comment("/* If the counter value doesn't match expectations, cause a deliberate");
+    comment("   error (WDR reference > 31) to end the program. */");
+    li(x2, 232);
+    if (x2 != x5) {
+      li(x2, 255);
+      ghost var iter := b256_iter_cons(x21, 0, heap[x21].b256);
+      let next_iter := bn_sid_safe(x0, false, 0, x2, false, iter);
+    }
 }
 
 #verbatim

--- a/impl/otbn/mont_loop.i.vad
+++ b/impl/otbn/mont_loop.i.vad
@@ -282,6 +282,7 @@ procedure mont_loop_1(
             y_it.buff, m_it.buff, prev_view, curr_view, j);
 
     ensures
+        x5 == old(x5);
         x6 == old(x6);
         x7 == old(x7);
         x8 == 4 + j + 1;
@@ -401,6 +402,7 @@ procedure mont_loop(
         montmul_inv(prev_view, x_it.buff, x_it.index-1, vars.y_it.buff, vars.rsa);
 
     ensures
+        x5 == old(x5);
         x6 == old(x6);
         x7 == old(x7);
         x9 == old(x9);
@@ -491,6 +493,7 @@ procedure mont_loop(
     comment("   re-used */");
     while (LoopImm(11))
         invariant
+            x5 == old(x5);
             x6 == old(x6);
             x7 == old(x7);
             x8 == 4 + j;

--- a/impl/otbn/montmul.i.vad
+++ b/impl/otbn/montmul.i.vad
@@ -47,6 +47,7 @@ procedure montmul_0(ghost vars: mvars)
         mvars_inv(vars, heap, x20, x19, x16, x17, NA, NA);
 
     ensures
+        x5 == old(x5);
         x9 == old(x9);
         x11 == 2;
         x20 == old(x20);
@@ -74,6 +75,7 @@ procedure montmul_0(ghost vars: mvars)
 
     while (LoopImm(12))
         invariant
+            x5 == old(x5);
             x9 == old(x9);
             x10 + loop_ctr == 4 + NUM_WORDS;
             x11 == 2;
@@ -119,6 +121,7 @@ procedure montmul(ghost vars: mvars)
         w31 == 0;
     
     ensures
+        x5 == old(x5);
         x8 == 4;
         x9 == old(x9);
         x10 == 4;
@@ -173,6 +176,7 @@ procedure montmul(ghost vars: mvars)
 
     while (LoopImm(12))
         invariant
+            x5 == old(x5);
             x9 == old(x9);
             x11 == 2;
             x21 == old(x21);


### PR DESCRIPTION
Adds a counter to `modexp` that counts iterations of all loops (the main montgomery-squaring loop and all `write_to_dmem` loops), and cause a deliberate error if the final count is not the expected value. This protects against scenarios in which an attacker is able to change the loop counter to try to skip iterations; in normal circumstances, the meaning of the code doesn't change at all.