### PR TITLE
Add support for the "unimp" pseudo-instruction

### DIFF
--- a/arch/otbn/decls.i.vad
+++ b/arch/otbn/decls.i.vad
@@ -417,6 +417,16 @@ procedure nop()
     this := this.(mem := old(this).mem);
 }
 
+procedure unimp()
+    {:instruction Ins32(UNIMP)}
+    requires
+        false;
+{
+    reveal eval_code_opaque;
+    reveal valid_state_opaque;
+    this := this.(mem := old(this).mem);
+}
+
 procedure bn_add(inout dst: reg256, in src1: reg256, in src2: reg256, inline shift: shift_t, inline which_group: uint1)
     {:instruction Ins256(BN_ADD(dst, src1, src2, shift, which_group))}
     modifies

--- a/arch/otbn/machine.s.dfy
+++ b/arch/otbn/machine.s.dfy
@@ -100,6 +100,7 @@ module ot_machine {
         | CSRRS(grd: reg32_t, csr: uint12, grs1: reg32_t)
         | ECALL
         | NOP
+        | UNIMP
 
     datatype ins256 =
         | BN_ADD(wrd: reg256_t, wrs1: reg256_t, wrs2: reg256_t, shift: shift_t, fg: uint1)
@@ -790,6 +791,7 @@ predicate method while_overlap(c:code)
                 case LI(xrd, imm32) => eval_LI(xrd, imm32)
                 case ECALL => this
                 case NOP => this
+                case UNIMP => this
         }
 
         function method eval_ins256(wins: ins256): state

--- a/arch/otbn/machine.s.dfy
+++ b/arch/otbn/machine.s.dfy
@@ -791,7 +791,7 @@ predicate method while_overlap(c:code)
                 case LI(xrd, imm32) => eval_LI(xrd, imm32)
                 case ECALL => this
                 case NOP => this
-                case UNIMP => this
+                case UNIMP => this.(ok:=false)
         }
 
         function method eval_ins256(wins: ins256): state

--- a/arch/otbn/printer.s.dfy
+++ b/arch/otbn/printer.s.dfy
@@ -96,6 +96,9 @@ method printIns32(ins:ins32)
 
         case BN_NOP =>
             print("nop\n");
+
+        case UNIMP =>
+            print ("unimp\n");
         
 
 }

--- a/arch/otbn/printer.s.dfy
+++ b/arch/otbn/printer.s.dfy
@@ -94,11 +94,11 @@ method printIns32(ins:ins32)
         case ECALL => 
             print ("ecall ");
 
+        case UNIMP =>
+            print("unimp\n");
+
         case BN_NOP =>
             print("nop\n");
-
-        case UNIMP =>
-            print ("unimp\n");
         
 
 }

--- a/gen/otbn_modexp.s
+++ b/gen/otbn_modexp.s
@@ -111,8 +111,7 @@ modexp_var_3072_f4:
      error (WDR reference > 31) to end the program. */
   li x2, 232
   beq x2, x5, label_1
-  li x2, 255
-  bn.sid x0, 0(x2)
+  unimp
   label_1:
   ret
 

--- a/impl/otbn/modexp_var.i.vad
+++ b/impl/otbn/modexp_var.i.vad
@@ -155,19 +155,6 @@ procedure write_to_dmem(ghost iter: iter_t)
     next_iter := next_iter.(index := 0);
 }
 
-/* Causes a deliberate error in order to stop execution (e.g. if a possible
-   attack is detected). */
-procedure throw_error()
-
-    {:frame false}
-
-    requires false;
-{
-      li(x2, 255);
-      ghost var iter := b256_iter_cons(x21, 0, heap[x21].b256);
-      let next_iter := bn_sid_safe(x0, false, 0, x2, false, iter);
-}
-
 function mvars_init(
     vars: mvars,
     heap: heap_t,
@@ -503,7 +490,7 @@ procedure modexp_var_3072_f4(
     comment("   error (WDR reference > 31) to end the program. */");
     li(x2, 232);
     if (x2 != x5) {
-      throw_error();
+      unimp();
     }
 }
 


### PR DESCRIPTION
In #70 I added a `throw_error()` procedure that generated an invalid instruction. However, OTBN actually has an `unimp` pseudo-instruction that does the same thing. Here, I add support for that instruction directly to the machine model and replace `throw_error`.